### PR TITLE
Disable bStats on Sponge by default

### DIFF
--- a/bstats-sponge-lite/src/main/java/org/bstats/sponge/MetricsLite.java
+++ b/bstats-sponge-lite/src/main/java/org/bstats/sponge/MetricsLite.java
@@ -274,7 +274,7 @@ public class MetricsLite {
             node = configurationLoader.load();
 
             // Add default values
-            node.getNode("enabled").setValue(true);
+            node.getNode("enabled").setValue(false);
             // Every server gets it's unique random id.
             node.getNode("serverUuid").setValue(UUID.randomUUID().toString());
             // Should failed request be logged?
@@ -294,7 +294,7 @@ public class MetricsLite {
         }
 
         // Load configuration
-        enabled = node.getNode("enabled").getBoolean(true);
+        enabled = node.getNode("enabled").getBoolean(false);
         serverUUID = node.getNode("serverUuid").getString();
         logFailedRequests = node.getNode("logFailedRequests").getBoolean(false);
     }

--- a/bstats-sponge/src/main/java/org/bstats/sponge/Metrics.java
+++ b/bstats-sponge/src/main/java/org/bstats/sponge/Metrics.java
@@ -298,7 +298,7 @@ public class Metrics {
             node = configurationLoader.load();
 
             // Add default values
-            node.getNode("enabled").setValue(true);
+            node.getNode("enabled").setValue(false);
             // Every server gets it's unique random id.
             node.getNode("serverUuid").setValue(UUID.randomUUID().toString());
             // Should failed request be logged?
@@ -318,7 +318,7 @@ public class Metrics {
         }
 
         // Load configuration
-        enabled = node.getNode("enabled").getBoolean(true);
+        enabled = node.getNode("enabled").getBoolean(false);
         serverUUID = node.getNode("serverUuid").getString();
         logFailedRequests = node.getNode("logFailedRequests").getBoolean(false);
     }


### PR DESCRIPTION
Per the Ore plugin submission guidelines
(https://docs.spongepowered.org/stable/en/ore/guidelines.html#external-connections-web-api-phoning-home-etc),
all Sponge plugins should have connections to external services
(including plugin metrics) disabled by default.

This commit ensures that plugins are able to include bStats in their
project without needing to make any changes to become compliant with
Sponge's guidelines.