### PR TITLE
Add Velocity

### DIFF
--- a/bstats-velocity-lite/pom.xml
+++ b/bstats-velocity-lite/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>bstats</artifactId>
+        <groupId>org.bstats</groupId>
+        <version>1.2</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>bstats-velocity-lite</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <excludes>
+                        <exclude>src/examples/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>velocity-repo</id>
+            <url>https://repo.velocitypowered.com/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>javadoc</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bstats-velocity-lite/pom.xml
+++ b/bstats-velocity-lite/pom.xml
@@ -71,14 +71,6 @@
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
             <version>1.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.velocitypowered</groupId>
-            <artifactId>velocity-api</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <type>javadoc</type>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bstats-velocity-lite/src/main/java/org/bstats/velocity/MetricsLite.java
+++ b/bstats-velocity-lite/src/main/java/org/bstats/velocity/MetricsLite.java
@@ -41,7 +41,7 @@ public class MetricsLite {
         if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
             // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
             final String defaultPackage = new String(
-                    new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's', '.', 'b', 'u', 'n', 'g', 'e', 'e', 'c', 'o', 'r', 'd'});
+                    new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's', '.', 'v', 'e', 'l', 'o', 'c', 'i', 't', 'y'});
             final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
             // We want to make sure nobody just copy & pastes the example and use the wrong package names
             if (MetricsLite.class.getPackage().getName().equals(defaultPackage) || MetricsLite.class.getPackage().getName().equals(examplePackage)) {

--- a/bstats-velocity-lite/src/main/java/org/bstats/velocity/MetricsLite.java
+++ b/bstats-velocity-lite/src/main/java/org/bstats/velocity/MetricsLite.java
@@ -1,0 +1,407 @@
+package org.bstats.velocity;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.moandjiezana.toml.Toml;
+import com.velocitypowered.api.plugin.PluginContainer;
+import com.velocitypowered.api.proxy.ProxyServer;
+
+import javax.net.ssl.HttpsURLConnection;
+
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * bStats collects some data for plugin authors.
+ *
+ * Check out https://bStats.org/ to learn more about bStats!
+ */
+public class MetricsLite {
+
+    static {
+        // You can use the property to disable the check in your test environment
+        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
+            // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
+            final String defaultPackage = new String(
+                    new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's', '.', 'b', 'u', 'n', 'g', 'e', 'e', 'c', 'o', 'r', 'd'});
+            final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
+            // We want to make sure nobody just copy & pastes the example and use the wrong package names
+            if (MetricsLite.class.getPackage().getName().equals(defaultPackage) || MetricsLite.class.getPackage().getName().equals(examplePackage)) {
+                throw new IllegalStateException("bStats Metrics class has not been relocated correctly!");
+            }
+        }
+    }
+
+    // The version of this bStats class
+    public static final int B_STATS_VERSION = 1;
+
+    // The url to which the data is sent
+    private static final String URL = "https://bStats.org/submitData/velocity";
+
+    // The plugin
+    private final PluginContainer plugin;
+
+    // The logger
+    private final Logger pluginLogger;
+
+    // The proxy
+    private final ProxyServer proxy;
+
+    // Is bStats enabled on this server?
+    private boolean enabled;
+
+    // The uuid of the server
+    private String serverUUID;
+
+    // Should failed requests be logged?
+    private boolean logFailedRequests = false;
+
+    // Should the sent data be logged?
+    private static boolean logSentData;
+
+    // Should the response text be logged?
+    private static boolean logResponseStatusText;
+
+    // A list with all known metrics class objects including this one
+    private static final List<Object> knownMetricsInstances = new ArrayList<>();
+
+    public MetricsLite(PluginContainer plugin, ProxyServer proxy, Logger pluginLogger) {
+        this.plugin = plugin;
+        this.proxy = proxy;
+        this.pluginLogger = pluginLogger;
+
+        try {
+            loadConfig();
+        } catch (IOException e) {
+            // Failed to load configuration
+            pluginLogger.warn("Failed to load bStats config!", e);
+            return;
+        }
+
+        // We are not allowed to send data about this server :(
+        if (!enabled) {
+            return;
+        }
+
+        Class<?> usedMetricsClass = getFirstBStatsClass();
+        if (usedMetricsClass == null) {
+            // Failed to get first metrics class
+            return;
+        }
+        if (usedMetricsClass == getClass()) {
+            // We are the first! :)
+            linkMetrics(this);
+            startSubmitting();
+        } else {
+            // We aren't the first so we link to the first metrics class
+            try {
+                usedMetricsClass.getMethod("linkMetrics", Object.class).invoke(null,this);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                if (logFailedRequests) {
+                    pluginLogger.warn("Failed to link to first metrics class " + usedMetricsClass.getName() + "!", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Links an other metrics class with this class.
+     * This method is called using Reflection.
+     *
+     * @param metrics An object of the metrics class to link.
+     */
+    public static void linkMetrics(Object metrics) {
+        knownMetricsInstances.add(metrics);
+    }
+
+    /**
+     * Gets the plugin specific data.
+     * This method is called using Reflection.
+     *
+     * @return The plugin specific data.
+     */
+    public JsonObject getPluginData() {
+        JsonObject data = new JsonObject();
+
+        String pluginName = plugin.getDescription().getName().get();
+        String pluginVersion = plugin.getDescription().getVersion().get();
+
+        data.addProperty("pluginName", pluginName);
+        data.addProperty("pluginVersion", pluginVersion);
+
+        JsonArray customCharts = new JsonArray();
+        data.add("customCharts", customCharts);
+
+        return data;
+    }
+
+    private void startSubmitting() {
+        proxy.getScheduler().buildTask(plugin, new Runnable() {
+            @Override
+            public void run() {
+                // The data collection is async, as well as sending the data
+                // Bungeecord does not have a main thread, everything is async
+                submitData();
+            }
+        }).delay(2, TimeUnit.MINUTES).repeat(30, TimeUnit.MINUTES).schedule();
+        // Submit the data every 30 minutes, first time after 2 minutes to give other plugins enough time to start
+        // WARNING: Changing the frequency has no effect but your plugin WILL be blocked/deleted!
+        // WARNING: Just don't do it!
+    }
+
+    /**
+     * Gets the server specific data.
+     *
+     * @return The server specific data.
+     */
+    private JsonObject getServerData() {
+        // Minecraft specific data
+        int playerAmount = proxy.getPlayerCount();
+        playerAmount = playerAmount > 500 ? 500 : playerAmount;
+        int onlineMode = proxy.getConfiguration().isOnlineMode() ? 1 : 0;
+        String velocityVersion = proxy.getClass().getPackage().getImplementationVersion();
+        int managedServers = proxy.getAllServers().size();
+
+        // OS/Java specific data
+        String javaVersion = System.getProperty("java.version");
+        String osName = System.getProperty("os.name");
+        String osArch = System.getProperty("os.arch");
+        String osVersion = System.getProperty("os.version");
+        int coreCount = Runtime.getRuntime().availableProcessors();
+
+        JsonObject data = new JsonObject();
+
+        data.addProperty("serverUUID", serverUUID);
+
+        data.addProperty("playerAmount", playerAmount);
+        data.addProperty("managedServers", managedServers);
+        data.addProperty("onlineMode", onlineMode);
+        data.addProperty("velocityVersion", velocityVersion);
+
+        data.addProperty("javaVersion", javaVersion);
+        data.addProperty("osName", osName);
+        data.addProperty("osArch", osArch);
+        data.addProperty("osVersion", osVersion);
+        data.addProperty("coreCount", coreCount);
+
+        return data;
+    }
+
+    /**
+     * Collects the data and sends it afterwards.
+     */
+    private void submitData() {
+        final JsonObject data = getServerData();
+
+        final JsonArray pluginData = new JsonArray();
+        // Search for all other bStats Metrics classes to get their plugin data
+        for (Object metrics : knownMetricsInstances) {
+            try {
+                Object plugin = metrics.getClass().getMethod("getPluginData").invoke(metrics);
+                if (plugin instanceof JsonObject) {
+                    pluginData.add((JsonObject) plugin);
+                }
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) { }
+        }
+
+        data.add("plugins", pluginData);
+
+        try {
+            // Send the data
+            sendData(plugin, pluginLogger, data);
+        } catch (Exception e) {
+            // Something went wrong! :(
+            if (logFailedRequests) {
+                pluginLogger.warn("Could not submit plugin stats!", e);
+            }
+        }
+    }
+
+    /**
+     * Loads the bStats configuration.
+     *
+     * @throws IOException If something did not work :(
+     */
+    private void loadConfig() throws IOException {
+        Path configPath = plugin.getDescription().getSource().get().getParent().resolve("bStats");
+        configPath.toFile().mkdirs();
+        File configFile = new File(configPath.toFile(), "config.toml");
+        if (!configFile.exists()) {
+            writeFile(configFile,
+                    "#bStats collects some data for plugin authors like how many servers are using their plugins.",
+                    "#To honor their work, you should not disable it.",
+                    "#This has nearly no effect on the server performance!",
+                    "#Check out https://bStats.org/ to learn more :)",
+                    "enabled = true",
+                    "serverUuid = \"" + UUID.randomUUID().toString() + "\"",
+                    "logFailedRequests = false",
+                    "logSentData = false",
+                    "logResponseStatusText = false");
+        }
+
+        Toml configuration = new Toml().read(configFile);
+
+        // Load configuration
+        enabled = configuration.getBoolean("enabled", true);
+        serverUUID = configuration.getString("serverUuid");
+        logFailedRequests = configuration.getBoolean("logFailedRequests", false);
+        logSentData = configuration.getBoolean("logSentData", false);
+        logResponseStatusText = configuration.getBoolean("logResponseStatusText", false);
+    }
+
+    /**
+     * Gets the first bStat Metrics class.
+     *
+     * @return The first bStats metrics class.
+     */
+    private Class<?> getFirstBStatsClass() {
+        Path configPath = plugin.getDescription().getSource().get().getParent().resolve("bStats");
+        configPath.toFile().mkdirs();
+        File tempFile = new File(configPath.toFile(), "temp.txt");
+
+        try {
+            String className = readFile(tempFile);
+            if (className != null) {
+                try {
+                    // Let's check if a class with the given name exists.
+                    return Class.forName(className);
+                } catch (ClassNotFoundException ignored) { }
+            }
+            writeFile(tempFile, getClass().getName());
+            return getClass();
+        } catch (IOException e) {
+            if (logFailedRequests) {
+                pluginLogger.warn("Failed to get first bStats class!", e);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Reads the first line of the file.
+     *
+     * @param file The file to read. Cannot be null.
+     * @return The first line of the file or <code>null</code> if the file does not exist or is empty.
+     * @throws IOException If something did not work :(
+     */
+    private String readFile(File file) throws IOException {
+        if (!file.exists()) {
+            return null;
+        }
+        try (
+                FileReader fileReader = new FileReader(file);
+                BufferedReader bufferedReader =  new BufferedReader(fileReader);
+        ) {
+            return bufferedReader.readLine();
+        }
+    }
+
+    /**
+     * Writes a String to a file. It also adds a note for the user,
+     *
+     * @param file The file to write to. Cannot be null.
+     * @param lines The lines to write.
+     * @throws IOException If something did not work :(
+     */
+    private void writeFile(File file, String... lines) throws IOException {
+        if (!file.exists()) {
+            file.createNewFile();
+        }
+        try (
+                FileWriter fileWriter = new FileWriter(file);
+                BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)
+        ) {
+            for (String line : lines) {
+                bufferedWriter.write(line);
+                bufferedWriter.newLine();
+            }
+        }
+    }
+
+    /**
+     * Sends the data to the bStats server.
+     *
+     * @param plugin Any plugin. It's just used to get a logger instance.
+     * @param data The data to send.
+     * @throws Exception If the request failed.
+     */
+    private static void sendData(PluginContainer plugin, Logger pluginLogger, JsonObject data) throws Exception {
+        if (data == null) {
+            throw new IllegalArgumentException("Data cannot be null");
+        }
+        if (logSentData) {
+            pluginLogger.info("Sending data to bStats: " + data.toString());
+        }
+
+        HttpsURLConnection connection = (HttpsURLConnection) new URL(URL).openConnection();
+
+        // Compress the data to save bandwidth
+        byte[] compressedData = compress(data.toString());
+
+        // Add headers
+        connection.setRequestMethod("POST");
+        connection.addRequestProperty("Accept", "application/json");
+        connection.addRequestProperty("Connection", "close");
+        connection.addRequestProperty("Content-Encoding", "gzip"); // We gzip our request
+        connection.addRequestProperty("Content-Length", String.valueOf(compressedData.length));
+        connection.setRequestProperty("Content-Type", "application/json"); // We send our data in JSON format
+        connection.setRequestProperty("User-Agent", "MC-Server/" + B_STATS_VERSION);
+
+        // Send data
+        connection.setDoOutput(true);
+        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
+        outputStream.write(compressedData);
+        outputStream.flush();
+        outputStream.close();
+
+        InputStream inputStream = connection.getInputStream();
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+
+        StringBuilder builder = new StringBuilder();
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+            builder.append(line);
+        }
+        bufferedReader.close();
+        if (logResponseStatusText) {
+            pluginLogger.info("Sent data to bStats and received response: " + builder.toString());
+        }
+    }
+
+    /**
+     * Gzips the given String.
+     *
+     * @param str The string to gzip.
+     * @return The gzipped String.
+     * @throws IOException If the compression failed.
+     */
+    private static byte[] compress(final String str) throws IOException {
+        if (str == null) {
+            return null;
+        }
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
+        gzip.write(str.getBytes("UTF-8"));
+        gzip.close();
+        return outputStream.toByteArray();
+    }
+
+}

--- a/bstats-velocity/pom.xml
+++ b/bstats-velocity/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>bstats</artifactId>
+        <groupId>org.bstats</groupId>
+        <version>1.2</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>bstats-velocity</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <excludes>
+                        <exclude>src/examples/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>velocity-repo</id>
+            <url>https://repo.velocitypowered.com/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>javadoc</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bstats-velocity/pom.xml
+++ b/bstats-velocity/pom.xml
@@ -71,14 +71,6 @@
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
             <version>1.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.velocitypowered</groupId>
-            <artifactId>velocity-api</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <type>javadoc</type>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bstats-velocity/src/examples/java/ExamplePlugin.java
+++ b/bstats-velocity/src/examples/java/ExamplePlugin.java
@@ -1,25 +1,37 @@
-import net.md_5.bungee.api.plugin.Plugin;
-import org.bstats.bungeecord.Metrics;
+import org.slf4j.Logger;
 
-import java.util.concurrent.Callable;
+import com.google.inject.Inject;
+import com.velocitypowered.api.event.PostOrder;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.proxy.ProxyServer;
+import org.bstats.velocity.Metrics;
 
-public class ExamplePlugin extends Plugin {
-
-    @Override
-    public void onEnable() {
-        // All you have to do is adding this line in your onEnable method:
-        Metrics metrics = new Metrics(this);
-
-        // Optional: Add custom charts
-        metrics.addCustomChart(new Metrics.SimplePie("chart_id", new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                return "My value";
-            }
-        }));
-
-        // If you use Java 8 you can use Lambdas:
-        // metrics.addCustomChart(new Metrics.SimplePie("chart_id", () -> "My value"));
+@Plugin(id = "test", name = "Test", version = "1.0.0", description = "A test plugin", authors = { "me" })
+public class ExamplePlugin {
+    private ProxyServer proxy;
+    private Logger logger;
+    
+    private static ExamplePlugin plugin;
+    
+    @Inject
+    public ExamplePlugin(ProxyServer proxy, Logger logger) {
+        this.proxy = proxy;
+        this.logger = logger;
+        
+        this.plugin = this;
+        
+        proxy.getEventManager().register(this, ProxyInitializeEvent.class, PostOrder.NORMAL, new ExamplePluginInitEventHandler());
     }
-
+    
+    public static ExamplePlugin getInstance() {
+        return plugin;
+    }
+    
+    public ProxyServer getProxy() {
+        return proxy;
+    }
+    public Logger getLogger() {
+        return logger;
+    }
 }

--- a/bstats-velocity/src/examples/java/ExamplePlugin.java
+++ b/bstats-velocity/src/examples/java/ExamplePlugin.java
@@ -1,0 +1,25 @@
+import net.md_5.bungee.api.plugin.Plugin;
+import org.bstats.bungeecord.Metrics;
+
+import java.util.concurrent.Callable;
+
+public class ExamplePlugin extends Plugin {
+
+    @Override
+    public void onEnable() {
+        // All you have to do is adding this line in your onEnable method:
+        Metrics metrics = new Metrics(this);
+
+        // Optional: Add custom charts
+        metrics.addCustomChart(new Metrics.SimplePie("chart_id", new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return "My value";
+            }
+        }));
+
+        // If you use Java 8 you can use Lambdas:
+        // metrics.addCustomChart(new Metrics.SimplePie("chart_id", () -> "My value"));
+    }
+
+}

--- a/bstats-velocity/src/examples/java/ExamplePluginInitEventHandler.java
+++ b/bstats-velocity/src/examples/java/ExamplePluginInitEventHandler.java
@@ -10,7 +10,7 @@ public class ExamplePluginInitEventHandler implements EventHandler<ProxyInitiali
         ExamplePlugin plugin = ExamplePlugin.getInstance();
         
         // All you have to do is adding this line in your onEnable method:
-        Metrics metrics = new Metrics(plugin.getProxy().getPluginManager().fromInstance(plugin), plugin.getProxy(), plugin.getLogger());
+        Metrics metrics = new Metrics(plugin.getProxy().getPluginManager().fromInstance(plugin).get(), plugin.getProxy(), plugin.getLogger());
 
         // Optional: Add custom charts
         metrics.addCustomChart(new Metrics.SimplePie("chart_id", new Callable<String>() {

--- a/bstats-velocity/src/examples/java/ExamplePluginInitEventHandler.java
+++ b/bstats-velocity/src/examples/java/ExamplePluginInitEventHandler.java
@@ -1,0 +1,26 @@
+import java.util.concurrent.Callable;
+
+import com.velocitypowered.api.event.EventHandler;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+
+import org.bstats.velocity.Metrics;
+
+public class ExamplePluginInitEventHandler implements EventHandler<ProxyInitializeEvent> {
+    public void execute(ProxyInitializeEvent event) {
+        ExamplePlugin plugin = ExamplePlugin.getInstance();
+        
+        // All you have to do is adding this line in your onEnable method:
+        Metrics metrics = new Metrics(plugin.getProxy().getPluginManager().fromInstance(plugin), plugin.getProxy(), plugin.getLogger());
+
+        // Optional: Add custom charts
+        metrics.addCustomChart(new Metrics.SimplePie("chart_id", new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return "My value";
+            }
+        }));
+
+        // If you use Java 8 you can use Lambdas:
+        // metrics.addCustomChart(new Metrics.SimplePie("chart_id", () -> "My value"));
+    }
+}

--- a/bstats-velocity/src/main/java/org/bstats/velocity/Metrics.java
+++ b/bstats-velocity/src/main/java/org/bstats/velocity/Metrics.java
@@ -1,0 +1,774 @@
+package org.bstats.velocity;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.moandjiezana.toml.Toml;
+import com.velocitypowered.api.plugin.PluginContainer;
+import com.velocitypowered.api.proxy.ProxyServer;
+
+import javax.net.ssl.HttpsURLConnection;
+
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * bStats collects some data for plugin authors.
+ *
+ * Check out https://bStats.org/ to learn more about bStats!
+ */
+public class Metrics {
+
+    static {
+        // You can use the property to disable the check in your test environment
+        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
+            // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
+            final String defaultPackage = new String(
+                    new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's', '.', 'b', 'u', 'n', 'g', 'e', 'e', 'c', 'o', 'r', 'd'});
+            final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
+            // We want to make sure nobody just copy & pastes the example and use the wrong package names
+            if (Metrics.class.getPackage().getName().equals(defaultPackage) || Metrics.class.getPackage().getName().equals(examplePackage)) {
+                throw new IllegalStateException("bStats Metrics class has not been relocated correctly!");
+            }
+        }
+    }
+
+    // The version of this bStats class
+    public static final int B_STATS_VERSION = 1;
+
+    // The url to which the data is sent
+    private static final String URL = "https://bStats.org/submitData/velocity";
+
+    // The plugin
+    private final PluginContainer plugin;
+
+    // The logger
+    private final Logger pluginLogger;
+
+    // The proxy
+    private final ProxyServer proxy;
+
+    // Is bStats enabled on this server?
+    private boolean enabled;
+
+    // The uuid of the server
+    private String serverUUID;
+
+    // Should failed requests be logged?
+    private boolean logFailedRequests = false;
+
+    // Should the sent data be logged?
+    private static boolean logSentData;
+
+    // Should the response text be logged?
+    private static boolean logResponseStatusText;
+
+    // A list with all known metrics class objects including this one
+    private static final List<Object> knownMetricsInstances = new ArrayList<>();
+
+    // A list with all custom charts
+    private final List<CustomChart> charts = new ArrayList<>();
+
+    public Metrics(PluginContainer plugin, ProxyServer proxy, Logger pluginLogger) {
+        this.plugin = plugin;
+        this.proxy = proxy;
+        this.pluginLogger = pluginLogger;
+
+        try {
+            loadConfig();
+        } catch (IOException e) {
+            // Failed to load configuration
+            pluginLogger.warn("Failed to load bStats config!", e);
+            return;
+        }
+
+        // We are not allowed to send data about this server :(
+        if (!enabled) {
+            return;
+        }
+
+        Class<?> usedMetricsClass = getFirstBStatsClass();
+        if (usedMetricsClass == null) {
+            // Failed to get first metrics class
+            return;
+        }
+        if (usedMetricsClass == getClass()) {
+            // We are the first! :)
+            linkMetrics(this);
+            startSubmitting();
+        } else {
+            // We aren't the first so we link to the first metrics class
+            try {
+                usedMetricsClass.getMethod("linkMetrics", Object.class).invoke(null,this);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                if (logFailedRequests) {
+                    pluginLogger.warn("Failed to link to first metrics class " + usedMetricsClass.getName() + "!", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if bStats is enabled.
+     *
+     * @return Whether bStats is enabled or not.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Adds a custom chart.
+     *
+     * @param chart The chart to add.
+     */
+    public void addCustomChart(CustomChart chart) {
+        if (chart == null) {
+            pluginLogger.warn("Chart cannot be null");
+        }
+        charts.add(chart);
+    }
+
+    /**
+     * Links an other metrics class with this class.
+     * This method is called using Reflection.
+     *
+     * @param metrics An object of the metrics class to link.
+     */
+    public static void linkMetrics(Object metrics) {
+        knownMetricsInstances.add(metrics);
+    }
+
+    /**
+     * Gets the plugin specific data.
+     * This method is called using Reflection.
+     *
+     * @return The plugin specific data.
+     */
+    public JsonObject getPluginData() {
+        JsonObject data = new JsonObject();
+
+        String pluginName = plugin.getDescription().getName().get();
+        String pluginVersion = plugin.getDescription().getVersion().get();
+
+        data.addProperty("pluginName", pluginName);
+        data.addProperty("pluginVersion", pluginVersion);
+
+        JsonArray customCharts = new JsonArray();
+        for (CustomChart customChart : charts) {
+            // Add the data of the custom charts
+            JsonObject chart = customChart.getRequestJsonObject(pluginLogger, logFailedRequests);
+            if (chart == null) { // If the chart is null, we skip it
+                continue;
+            }
+            customCharts.add(chart);
+        }
+        data.add("customCharts", customCharts);
+
+        return data;
+    }
+
+    private void startSubmitting() {
+        proxy.getScheduler().buildTask(plugin, new Runnable() {
+            @Override
+            public void run() {
+            // The data collection is async, as well as sending the data
+                // Bungeecord does not have a main thread, everything is async
+                submitData();
+            }
+        }).delay(2, TimeUnit.MINUTES).repeat(30, TimeUnit.MINUTES).schedule();
+        // Submit the data every 30 minutes, first time after 2 minutes to give other plugins enough time to start
+        // WARNING: Changing the frequency has no effect but your plugin WILL be blocked/deleted!
+        // WARNING: Just don't do it!
+    }
+
+    /**
+     * Gets the server specific data.
+     *
+     * @return The server specific data.
+     */
+    private JsonObject getServerData() {
+        // Minecraft specific data
+        int playerAmount = proxy.getPlayerCount();
+        playerAmount = playerAmount > 500 ? 500 : playerAmount;
+        int onlineMode = proxy.getConfiguration().isOnlineMode() ? 1 : 0;
+        String velocityVersion = proxy.getClass().getPackage().getImplementationVersion();
+        int managedServers = proxy.getAllServers().size();
+
+        // OS/Java specific data
+        String javaVersion = System.getProperty("java.version");
+        String osName = System.getProperty("os.name");
+        String osArch = System.getProperty("os.arch");
+        String osVersion = System.getProperty("os.version");
+        int coreCount = Runtime.getRuntime().availableProcessors();
+
+        JsonObject data = new JsonObject();
+
+        data.addProperty("serverUUID", serverUUID);
+
+        data.addProperty("playerAmount", playerAmount);
+        data.addProperty("managedServers", managedServers);
+        data.addProperty("onlineMode", onlineMode);
+        data.addProperty("velocityVersion", velocityVersion);
+
+        data.addProperty("javaVersion", javaVersion);
+        data.addProperty("osName", osName);
+        data.addProperty("osArch", osArch);
+        data.addProperty("osVersion", osVersion);
+        data.addProperty("coreCount", coreCount);
+
+        return data;
+    }
+
+    /**
+     * Collects the data and sends it afterwards.
+     */
+    private void submitData() {
+        final JsonObject data = getServerData();
+
+        final JsonArray pluginData = new JsonArray();
+        // Search for all other bStats Metrics classes to get their plugin data
+        for (Object metrics : knownMetricsInstances) {
+            try {
+                Object plugin = metrics.getClass().getMethod("getPluginData").invoke(metrics);
+                if (plugin instanceof JsonObject) {
+                    pluginData.add((JsonObject) plugin);
+                }
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) { }
+        }
+
+        data.add("plugins", pluginData);
+
+        try {
+            // Send the data
+            sendData(plugin, pluginLogger, data);
+        } catch (Exception e) {
+            // Something went wrong! :(
+            if (logFailedRequests) {
+                pluginLogger.warn("Could not submit plugin stats!", e);
+            }
+        }
+    }
+
+    /**
+     * Loads the bStats configuration.
+     *
+     * @throws IOException If something did not work :(
+     */
+    private void loadConfig() throws IOException {
+        Path configPath = plugin.getDescription().getSource().get().getParent().resolve("bStats");
+        configPath.toFile().mkdirs();
+        File configFile = new File(configPath.toFile(), "config.toml");
+        if (!configFile.exists()) {
+            writeFile(configFile,
+                    "#bStats collects some data for plugin authors like how many servers are using their plugins.",
+                    "#To honor their work, you should not disable it.",
+                    "#This has nearly no effect on the server performance!",
+                    "#Check out https://bStats.org/ to learn more :)",
+                    "enabled = true",
+                    "serverUuid = \"" + UUID.randomUUID().toString() + "\"",
+                    "logFailedRequests = false",
+                    "logSentData = false",
+                    "logResponseStatusText = false");
+        }
+
+        Toml configuration = new Toml().read(configFile);
+
+        // Load configuration
+        enabled = configuration.getBoolean("enabled", true);
+        serverUUID = configuration.getString("serverUuid");
+        logFailedRequests = configuration.getBoolean("logFailedRequests", false);
+        logSentData = configuration.getBoolean("logSentData", false);
+        logResponseStatusText = configuration.getBoolean("logResponseStatusText", false);
+    }
+
+    /**
+     * Gets the first bStat Metrics class.
+     *
+     * @return The first bStats metrics class.
+     */
+    private Class<?> getFirstBStatsClass() {
+        Path configPath = plugin.getDescription().getSource().get().getParent().resolve("bStats");
+        configPath.toFile().mkdirs();
+        File tempFile = new File(configPath.toFile(), "temp.txt");
+
+        try {
+            String className = readFile(tempFile);
+            if (className != null) {
+                try {
+                    // Let's check if a class with the given name exists.
+                    return Class.forName(className);
+                } catch (ClassNotFoundException ignored) { }
+            }
+            writeFile(tempFile, getClass().getName());
+            return getClass();
+        } catch (IOException e) {
+            if (logFailedRequests) {
+                pluginLogger.warn("Failed to get first bStats class!", e);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Reads the first line of the file.
+     *
+     * @param file The file to read. Cannot be null.
+     * @return The first line of the file or <code>null</code> if the file does not exist or is empty.
+     * @throws IOException If something did not work :(
+     */
+    private String readFile(File file) throws IOException {
+        if (!file.exists()) {
+            return null;
+        }
+        try (
+                FileReader fileReader = new FileReader(file);
+                BufferedReader bufferedReader =  new BufferedReader(fileReader);
+        ) {
+            return bufferedReader.readLine();
+        }
+    }
+
+    /**
+     * Writes a String to a file. It also adds a note for the user,
+     *
+     * @param file The file to write to. Cannot be null.
+     * @param lines The lines to write.
+     * @throws IOException If something did not work :(
+     */
+    private void writeFile(File file, String... lines) throws IOException {
+        if (!file.exists()) {
+            file.createNewFile();
+        }
+        try (
+                FileWriter fileWriter = new FileWriter(file);
+                BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)
+        ) {
+            for (String line : lines) {
+                bufferedWriter.write(line);
+                bufferedWriter.newLine();
+            }
+        }
+    }
+
+    /**
+     * Sends the data to the bStats server.
+     *
+     * @param plugin Any plugin. It's just used to get a logger instance.
+     * @param data The data to send.
+     * @throws Exception If the request failed.
+     */
+    private static void sendData(PluginContainer plugin, Logger pluginLogger, JsonObject data) throws Exception {
+        if (data == null) {
+            throw new IllegalArgumentException("Data cannot be null");
+        }
+        if (logSentData) {
+            pluginLogger.info("Sending data to bStats: " + data.toString());
+        }
+
+        HttpsURLConnection connection = (HttpsURLConnection) new URL(URL).openConnection();
+
+        // Compress the data to save bandwidth
+        byte[] compressedData = compress(data.toString());
+
+        // Add headers
+        connection.setRequestMethod("POST");
+        connection.addRequestProperty("Accept", "application/json");
+        connection.addRequestProperty("Connection", "close");
+        connection.addRequestProperty("Content-Encoding", "gzip"); // We gzip our request
+        connection.addRequestProperty("Content-Length", String.valueOf(compressedData.length));
+        connection.setRequestProperty("Content-Type", "application/json"); // We send our data in JSON format
+        connection.setRequestProperty("User-Agent", "MC-Server/" + B_STATS_VERSION);
+
+        // Send data
+        connection.setDoOutput(true);
+        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
+        outputStream.write(compressedData);
+        outputStream.flush();
+        outputStream.close();
+
+        InputStream inputStream = connection.getInputStream();
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+
+        StringBuilder builder = new StringBuilder();
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+            builder.append(line);
+        }
+        bufferedReader.close();
+        if (logResponseStatusText) {
+            pluginLogger.info("Sent data to bStats and received response: " + builder.toString());
+        }
+    }
+
+    /**
+     * Gzips the given String.
+     *
+     * @param str The string to gzip.
+     * @return The gzipped String.
+     * @throws IOException If the compression failed.
+     */
+    private static byte[] compress(final String str) throws IOException {
+        if (str == null) {
+            return null;
+        }
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
+        gzip.write(str.getBytes("UTF-8"));
+        gzip.close();
+        return outputStream.toByteArray();
+    }
+
+
+    /**
+     * Represents a custom chart.
+     */
+    public static abstract class CustomChart {
+
+        // The id of the chart
+        private final String chartId;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         */
+        CustomChart(String chartId) {
+            if (chartId == null || chartId.isEmpty()) {
+                throw new IllegalArgumentException("ChartId cannot be null or empty!");
+            }
+            this.chartId = chartId;
+        }
+
+        private JsonObject getRequestJsonObject(Logger logger, boolean logFailedRequests) {
+            JsonObject chart = new JsonObject();
+            chart.addProperty("chartId", chartId);
+            try {
+                JsonObject data = getChartData();
+                if (data == null) {
+                    // If the data is null we don't send the chart.
+                    return null;
+                }
+                chart.add("data", data);
+            } catch (Throwable t) {
+                if (logFailedRequests) {
+                    logger.warn("Failed to get data for custom chart with id " + chartId, t);
+                }
+                return null;
+            }
+            return chart;
+        }
+
+        protected abstract JsonObject getChartData() throws Exception;
+
+    }
+
+    /**
+     * Represents a custom simple pie.
+     */
+    public static class SimplePie extends CustomChart {
+
+        private final Callable<String> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SimplePie(String chartId, Callable<String> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObject getChartData() throws Exception {
+            JsonObject data = new JsonObject();
+            String value = callable.call();
+            if (value == null || value.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            data.addProperty("value", value);
+            return data;
+        }
+    }
+
+    /**
+     * Represents a custom advanced pie.
+     */
+    public static class AdvancedPie extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public AdvancedPie(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObject getChartData() throws Exception {
+            JsonObject data = new JsonObject();
+            JsonObject values = new JsonObject();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                if (entry.getValue() == 0) {
+                    continue; // Skip this invalid
+                }
+                allSkipped = false;
+                values.addProperty(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            data.add("values", values);
+            return data;
+        }
+    }
+
+    /**
+     * Represents a custom drilldown pie.
+     */
+    public static class DrilldownPie extends CustomChart {
+
+        private final Callable<Map<String, Map<String, Integer>>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public DrilldownPie(String chartId, Callable<Map<String, Map<String, Integer>>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        public JsonObject getChartData() throws Exception {
+            JsonObject data = new JsonObject();
+            JsonObject values = new JsonObject();
+            Map<String, Map<String, Integer>> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean reallyAllSkipped = true;
+            for (Map.Entry<String, Map<String, Integer>> entryValues : map.entrySet()) {
+                JsonObject value = new JsonObject();
+                boolean allSkipped = true;
+                for (Map.Entry<String, Integer> valueEntry : map.get(entryValues.getKey()).entrySet()) {
+                    value.addProperty(valueEntry.getKey(), valueEntry.getValue());
+                    allSkipped = false;
+                }
+                if (!allSkipped) {
+                    reallyAllSkipped = false;
+                    values.add(entryValues.getKey(), value);
+                }
+            }
+            if (reallyAllSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            data.add("values", values);
+            return data;
+        }
+    }
+
+    /**
+     * Represents a custom single line chart.
+     */
+    public static class SingleLineChart extends CustomChart {
+
+        private final Callable<Integer> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SingleLineChart(String chartId, Callable<Integer> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObject getChartData() throws Exception {
+            JsonObject data = new JsonObject();
+            int value = callable.call();
+            if (value == 0) {
+                // Null = skip the chart
+                return null;
+            }
+            data.addProperty("value", value);
+            return data;
+        }
+
+    }
+
+    /**
+     * Represents a custom multi line chart.
+     */
+    public static class MultiLineChart extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public MultiLineChart(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObject getChartData() throws Exception {
+            JsonObject data = new JsonObject();
+            JsonObject values = new JsonObject();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                if (entry.getValue() == 0) {
+                    continue; // Skip this invalid
+                }
+                allSkipped = false;
+                values.addProperty(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            data.add("values", values);
+            return data;
+        }
+
+    }
+
+    /**
+     * Represents a custom simple bar chart.
+     */
+    public static class SimpleBarChart extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SimpleBarChart(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObject getChartData() throws Exception {
+            JsonObject data = new JsonObject();
+            JsonObject values = new JsonObject();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                JsonArray categoryValues = new JsonArray();
+                categoryValues.add(new JsonPrimitive(entry.getValue()));
+                values.add(entry.getKey(), categoryValues);
+            }
+            data.add("values", values);
+            return data;
+        }
+
+    }
+
+    /**
+     * Represents a custom advanced bar chart.
+     */
+    public static class AdvancedBarChart extends CustomChart {
+
+        private final Callable<Map<String, int[]>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public AdvancedBarChart(String chartId, Callable<Map<String, int[]>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObject getChartData() throws Exception {
+            JsonObject data = new JsonObject();
+            JsonObject values = new JsonObject();
+            Map<String, int[]> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, int[]> entry : map.entrySet()) {
+                if (entry.getValue().length == 0) {
+                    continue; // Skip this invalid
+                }
+                allSkipped = false;
+                JsonArray categoryValues = new JsonArray();
+                for (int categoryValue : entry.getValue()) {
+                    categoryValues.add(new JsonPrimitive(categoryValue));
+                }
+                values.add(entry.getKey(), categoryValues);
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            data.add("values", values);
+            return data;
+        }
+
+    }
+
+}

--- a/bstats-velocity/src/main/java/org/bstats/velocity/Metrics.java
+++ b/bstats-velocity/src/main/java/org/bstats/velocity/Metrics.java
@@ -44,7 +44,7 @@ public class Metrics {
         if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
             // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
             final String defaultPackage = new String(
-                    new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's', '.', 'b', 'u', 'n', 'g', 'e', 'e', 'c', 'o', 'r', 'd'});
+                    new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's', '.', 'v', 'e', 'l', 'o', 'c', 'i', 't', 'y'});
             final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
             // We want to make sure nobody just copy & pastes the example and use the wrong package names
             if (Metrics.class.getPackage().getName().equals(defaultPackage) || Metrics.class.getPackage().getName().equals(examplePackage)) {

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <module>bstats-bukkit-lite</module>
         <module>bstats-bungeecord-lite</module>
         <module>bstats-sponge-lite</module>
-		<module>bstats-velocity-lite</module>
+        <module>bstats-velocity-lite</module>
     </modules>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,11 @@
         <module>bstats-bukkit</module>
         <module>bstats-bungeecord</module>
         <module>bstats-sponge</module>
+		<module>bstats-velocity</module>
         <module>bstats-bukkit-lite</module>
         <module>bstats-bungeecord-lite</module>
         <module>bstats-sponge-lite</module>
+		<module>bstats-velocity-lite</module>
     </modules>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <module>bstats-bukkit</module>
         <module>bstats-bungeecord</module>
         <module>bstats-sponge</module>
-		<module>bstats-velocity</module>
+        <module>bstats-velocity</module>
         <module>bstats-bukkit-lite</module>
         <module>bstats-bungeecord-lite</module>
         <module>bstats-sponge-lite</module>


### PR DESCRIPTION
This PR adds Velocity to the list of available server types.

Unfortunately there's no way to get the proxy via the plugin, or the logger via the proxy, or any of combination of those. Creating a new Metrics class will require all three.

As a plugin, you'd want to create the Metrics class in Velocity's init event since you can't get the PluginContainer for your plugin in the plugin constructor.