### PR TITLE
Actually assign values of logSentData and logResponseStatusText

### DIFF
--- a/bstats-bukkit-lite/src/main/java/org/bstats/bukkit/MetricsLite.java
+++ b/bstats-bukkit-lite/src/main/java/org/bstats/bukkit/MetricsLite.java
@@ -113,6 +113,8 @@ public class MetricsLite {
         // Load the data
         serverUUID = config.getString("serverUuid");
         logFailedRequests = config.getBoolean("logFailedRequests", false);
+        logSentData = config.getBoolean("logSentData", false);
+        logResponseStatusText = config.getBoolean("logResponseStatusText", false);
         enabled = config.getBoolean("enabled", true);
         if (enabled) {
             boolean found = false;


### PR DESCRIPTION
Well, in the Bukkit Lite Metrics file, these two values aren't actually assigned