### PR TITLE
Fix compatibility with bar charts on Bukkit versions before 1.12 and cleanup code

### DIFF
--- a/bstats-bukkit/src/main/java/org/bstats/bukkit/Metrics.java
+++ b/bstats-bukkit/src/main/java/org/bstats/bukkit/Metrics.java
@@ -289,7 +289,6 @@ public class Metrics {
                                 if (logFailedRequests) {
                                     this.plugin.getLogger().log(Level.SEVERE, "Encountered unexpected exception", e);
                                 }
-                                continue; // continue looping since we cannot do any other thing.
                             }
                         }
                     } catch (NullPointerException | NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) { }
@@ -300,17 +299,14 @@ public class Metrics {
         data.add("plugins", pluginData);
 
         // Create a new thread for the connection to the bStats server
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    // Send the data
-                    sendData(plugin, data);
-                } catch (Exception e) {
-                    // Something went wrong! :(
-                    if (logFailedRequests) {
-                        plugin.getLogger().log(Level.WARNING, "Could not submit plugin stats of " + plugin.getName(), e);
-                    }
+        new Thread(() -> {
+            try {
+                // Send the data
+                sendData(plugin, data);
+            } catch (Exception e) {
+                // Something went wrong! :(
+                if (logFailedRequests) {
+                    plugin.getLogger().log(Level.WARNING, "Could not submit plugin stats of " + plugin.getName(), e);
                 }
             }
         }).start();
@@ -331,7 +327,7 @@ public class Metrics {
             throw new IllegalAccessException("This method must not be called from the main thread!");
         }
         if (logSentData) {
-            plugin.getLogger().info("Sending data to bStats: " + data.toString());
+            plugin.getLogger().info("Sending data to bStats: " + data);
         }
         HttpsURLConnection connection = (HttpsURLConnection) new URL(URL).openConnection();
 
@@ -349,22 +345,20 @@ public class Metrics {
 
         // Send data
         connection.setDoOutput(true);
-        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
-        outputStream.write(compressedData);
-        outputStream.flush();
-        outputStream.close();
-
-        InputStream inputStream = connection.getInputStream();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+            outputStream.write(compressedData);
+        }
 
         StringBuilder builder = new StringBuilder();
-        String line;
-        while ((line = bufferedReader.readLine()) != null) {
-            builder.append(line);
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                builder.append(line);
+            }
         }
-        bufferedReader.close();
+
         if (logResponseStatusText) {
-            plugin.getLogger().info("Sent data to bStats and received response: " + builder.toString());
+            plugin.getLogger().info("Sent data to bStats and received response: " + builder);
         }
     }
 
@@ -380,9 +374,9 @@ public class Metrics {
             return null;
         }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
-        gzip.write(str.getBytes(StandardCharsets.UTF_8));
-        gzip.close();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+            gzip.write(str.getBytes(StandardCharsets.UTF_8));
+        }
         return outputStream.toByteArray();
     }
 

--- a/bstats-bukkit/src/main/java/org/bstats/bukkit/Metrics.java
+++ b/bstats-bukkit/src/main/java/org/bstats/bukkit/Metrics.java
@@ -3,6 +3,7 @@ package org.bstats.bukkit;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
@@ -658,7 +659,7 @@ public class Metrics {
             }
             for (Map.Entry<String, Integer> entry : map.entrySet()) {
                 JsonArray categoryValues = new JsonArray();
-                categoryValues.add(entry.getValue());
+                categoryValues.add(new JsonPrimitive(entry.getValue()));
                 values.add(entry.getKey(), categoryValues);
             }
             data.add("values", values);
@@ -702,7 +703,7 @@ public class Metrics {
                 allSkipped = false;
                 JsonArray categoryValues = new JsonArray();
                 for (int categoryValue : entry.getValue()) {
-                    categoryValues.add(categoryValue);
+                    categoryValues.add(new JsonPrimitive(categoryValue));
                 }
                 values.add(entry.getKey(), categoryValues);
             }

--- a/bstats-bungeecord-lite/src/main/java/org/bstats/bungeecord/MetricsLite.java
+++ b/bstats-bungeecord-lite/src/main/java/org/bstats/bungeecord/MetricsLite.java
@@ -12,7 +12,6 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -149,7 +148,7 @@ public class MetricsLite {
     private void startSubmitting() {
         // The data collection is async, as well as sending the data
         // Bungeecord does not have a main thread, everything is async
-        plugin.getProxy().getScheduler().schedule(plugin, () -> submitData(), 2, 30, TimeUnit.MINUTES);
+        plugin.getProxy().getScheduler().schedule(plugin, this::submitData, 2, 30, TimeUnit.MINUTES);
         // Submit the data every 30 minutes, first time after 2 minutes to give other plugins enough time to start
         // WARNING: Changing the frequency has no effect but your plugin WILL be blocked/deleted!
         // WARNING: Just don't do it!
@@ -162,8 +161,7 @@ public class MetricsLite {
      */
     private JsonObject getServerData() {
         // Minecraft specific data
-        int playerAmount = plugin.getProxy().getOnlineCount();
-        playerAmount = playerAmount > 500 ? 500 : playerAmount;
+        int playerAmount = Math.min(plugin.getProxy().getOnlineCount(), 500);
         int onlineMode = plugin.getProxy().getConfig().isOnlineMode() ? 1 : 0;
         String bungeecordVersion = plugin.getProxy().getVersion();
         int managedServers = plugin.getProxy().getServers().size();
@@ -229,9 +227,9 @@ public class MetricsLite {
      * @throws IOException If something did not work :(
      */
     private void loadConfig() throws IOException {
-        Path configPath = plugin.getDataFolder().toPath().getParent().resolve("bStats");
-        configPath.toFile().mkdirs();
-        File configFile = new File(configPath.toFile(), "config.yml");
+        File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
+        bStatsFolder.mkdirs();
+        File configFile = new File(bStatsFolder, "config.yml");
         if (!configFile.exists()) {
             writeFile(configFile,
                     "#bStats collects some data for plugin authors like how many servers are using their plugins.",
@@ -239,7 +237,7 @@ public class MetricsLite {
                     "#This has nearly no effect on the server performance!",
                     "#Check out https://bStats.org/ to learn more :)",
                     "enabled: true",
-                    "serverUuid: \"" + UUID.randomUUID().toString() + "\"",
+                    "serverUuid: \"" + UUID.randomUUID() + "\"",
                     "logFailedRequests: false",
                     "logSentData: false",
                     "logResponseStatusText: false");
@@ -261,9 +259,9 @@ public class MetricsLite {
      * @return The first bStats metrics class.
      */
     private Class<?> getFirstBStatsClass() {
-        Path configPath = plugin.getDataFolder().toPath().getParent().resolve("bStats");
-        configPath.toFile().mkdirs();
-        File tempFile = new File(configPath.toFile(), "temp.txt");
+        File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
+        bStatsFolder.mkdirs();
+        File tempFile = new File(bStatsFolder, "temp.txt");
 
         try {
             String className = readFile(tempFile);
@@ -287,17 +285,14 @@ public class MetricsLite {
      * Reads the first line of the file.
      *
      * @param file The file to read. Cannot be null.
-     * @return The first line of the file or <code>null</code> if the file does not exist or is empty.
+     * @return The first line of the file or {@code null} if the file does not exist or is empty.
      * @throws IOException If something did not work :(
      */
     private String readFile(File file) throws IOException {
         if (!file.exists()) {
             return null;
         }
-        try (
-                FileReader fileReader = new FileReader(file);
-                BufferedReader bufferedReader = new BufferedReader(fileReader);
-        ) {
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
             return bufferedReader.readLine();
         }
     }
@@ -310,13 +305,7 @@ public class MetricsLite {
      * @throws IOException If something did not work :(
      */
     private void writeFile(File file, String... lines) throws IOException {
-        if (!file.exists()) {
-            file.createNewFile();
-        }
-        try (
-                FileWriter fileWriter = new FileWriter(file);
-                BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)
-        ) {
+        try (BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(file))) {
             for (String line : lines) {
                 bufferedWriter.write(line);
                 bufferedWriter.newLine();
@@ -336,7 +325,7 @@ public class MetricsLite {
             throw new IllegalArgumentException("Data cannot be null");
         }
         if (logSentData) {
-            plugin.getLogger().info("Sending data to bStats: " + data.toString());
+            plugin.getLogger().info("Sending data to bStats: " + data);
         }
 
         HttpsURLConnection connection = (HttpsURLConnection) new URL(URL).openConnection();
@@ -355,22 +344,20 @@ public class MetricsLite {
 
         // Send data
         connection.setDoOutput(true);
-        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
-        outputStream.write(compressedData);
-        outputStream.flush();
-        outputStream.close();
-
-        InputStream inputStream = connection.getInputStream();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+            outputStream.write(compressedData);
+        }
 
         StringBuilder builder = new StringBuilder();
-        String line;
-        while ((line = bufferedReader.readLine()) != null) {
-            builder.append(line);
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                builder.append(line);
+            }
         }
-        bufferedReader.close();
+
         if (logResponseStatusText) {
-            plugin.getLogger().info("Sent data to bStats and received response: " + builder.toString());
+            plugin.getLogger().info("Sent data to bStats and received response: " + builder);
         }
     }
 
@@ -386,9 +373,9 @@ public class MetricsLite {
             return null;
         }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
-        gzip.write(str.getBytes(StandardCharsets.UTF_8));
-        gzip.close();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+            gzip.write(str.getBytes(StandardCharsets.UTF_8));
+        }
         return outputStream.toByteArray();
     }
 

--- a/bstats-bungeecord/src/main/java/org/bstats/bungeecord/Metrics.java
+++ b/bstats-bungeecord/src/main/java/org/bstats/bungeecord/Metrics.java
@@ -13,7 +13,6 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -189,8 +188,7 @@ public class Metrics {
      */
     private JsonObject getServerData() {
         // Minecraft specific data
-        int playerAmount = plugin.getProxy().getOnlineCount();
-        playerAmount = playerAmount > 500 ? 500 : playerAmount;
+        int playerAmount = Math.min(plugin.getProxy().getOnlineCount(), 500);
         int onlineMode = plugin.getProxy().getConfig().isOnlineMode() ? 1 : 0;
         String bungeecordVersion = plugin.getProxy().getVersion();
         int managedServers = plugin.getProxy().getServers().size();
@@ -256,9 +254,9 @@ public class Metrics {
      * @throws IOException If something did not work :(
      */
     private void loadConfig() throws IOException {
-        Path configPath = plugin.getDataFolder().toPath().getParent().resolve("bStats");
-        configPath.toFile().mkdirs();
-        File configFile = new File(configPath.toFile(), "config.yml");
+        File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
+        bStatsFolder.mkdirs();
+        File configFile = new File(bStatsFolder, "config.yml");
         if (!configFile.exists()) {
             writeFile(configFile,
                     "#bStats collects some data for plugin authors like how many servers are using their plugins.",
@@ -266,7 +264,7 @@ public class Metrics {
                     "#This has nearly no effect on the server performance!",
                     "#Check out https://bStats.org/ to learn more :)",
                     "enabled: true",
-                    "serverUuid: \"" + UUID.randomUUID().toString() + "\"",
+                    "serverUuid: \"" + UUID.randomUUID() + "\"",
                     "logFailedRequests: false",
                     "logSentData: false",
                     "logResponseStatusText: false");
@@ -288,9 +286,9 @@ public class Metrics {
      * @return The first bStats metrics class.
      */
     private Class<?> getFirstBStatsClass() {
-        Path configPath = plugin.getDataFolder().toPath().getParent().resolve("bStats");
-        configPath.toFile().mkdirs();
-        File tempFile = new File(configPath.toFile(), "temp.txt");
+        File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
+        bStatsFolder.mkdirs();
+        File tempFile = new File(bStatsFolder, "temp.txt");
 
         try {
             String className = readFile(tempFile);
@@ -314,17 +312,14 @@ public class Metrics {
      * Reads the first line of the file.
      *
      * @param file The file to read. Cannot be null.
-     * @return The first line of the file or <code>null</code> if the file does not exist or is empty.
+     * @return The first line of the file or {@code null} if the file does not exist or is empty.
      * @throws IOException If something did not work :(
      */
     private String readFile(File file) throws IOException {
         if (!file.exists()) {
             return null;
         }
-        try (
-                FileReader fileReader = new FileReader(file);
-                BufferedReader bufferedReader = new BufferedReader(fileReader);
-        ) {
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
             return bufferedReader.readLine();
         }
     }
@@ -337,13 +332,7 @@ public class Metrics {
      * @throws IOException If something did not work :(
      */
     private void writeFile(File file, String... lines) throws IOException {
-        if (!file.exists()) {
-            file.createNewFile();
-        }
-        try (
-                FileWriter fileWriter = new FileWriter(file);
-                BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)
-        ) {
+        try (BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(file))) {
             for (String line : lines) {
                 bufferedWriter.write(line);
                 bufferedWriter.newLine();
@@ -363,7 +352,7 @@ public class Metrics {
             throw new IllegalArgumentException("Data cannot be null");
         }
         if (logSentData) {
-            plugin.getLogger().info("Sending data to bStats: " + data.toString());
+            plugin.getLogger().info("Sending data to bStats: " + data);
         }
 
         HttpsURLConnection connection = (HttpsURLConnection) new URL(URL).openConnection();
@@ -382,22 +371,21 @@ public class Metrics {
 
         // Send data
         connection.setDoOutput(true);
-        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
-        outputStream.write(compressedData);
-        outputStream.flush();
-        outputStream.close();
-
-        InputStream inputStream = connection.getInputStream();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+            outputStream.write(compressedData);
+        }
 
         StringBuilder builder = new StringBuilder();
-        String line;
-        while ((line = bufferedReader.readLine()) != null) {
-            builder.append(line);
+
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                builder.append(line);
+            }
         }
-        bufferedReader.close();
+
         if (logResponseStatusText) {
-            plugin.getLogger().info("Sent data to bStats and received response: " + builder.toString());
+            plugin.getLogger().info("Sent data to bStats and received response: " + builder);
         }
     }
 
@@ -413,9 +401,9 @@ public class Metrics {
             return null;
         }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
-        gzip.write(str.getBytes(StandardCharsets.UTF_8));
-        gzip.close();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+            gzip.write(str.getBytes(StandardCharsets.UTF_8));
+        }
         return outputStream.toByteArray();
     }
 

--- a/bstats-sponge-lite/src/main/java/org/bstats/sponge/Metrics.java
+++ b/bstats-sponge-lite/src/main/java/org/bstats/sponge/Metrics.java
@@ -5,7 +5,7 @@ import org.spongepowered.api.plugin.PluginContainer;
 
 import java.util.List;
 
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings("unused")
 public interface Metrics {
     /**
      * Cancels this instance's scheduled data sending.

--- a/bstats-sponge-lite/src/main/java/org/bstats/sponge/MetricsLite2.java
+++ b/bstats-sponge-lite/src/main/java/org/bstats/sponge/MetricsLite2.java
@@ -222,11 +222,10 @@ public class MetricsLite2 implements Metrics {
 
         String pluginName = plugin.getName();
         String pluginVersion = plugin.getVersion().orElse("unknown");
-        int revision = getRevision();
 
         data.addProperty("pluginName", pluginName);
         data.addProperty("pluginVersion", pluginVersion);
-        data.addProperty("metricsRevision", revision);
+        data.addProperty("metricsRevision", B_STATS_CLASS_REVISION);
 
         JsonArray customCharts = new JsonArray();
         data.add("customCharts", customCharts);
@@ -321,14 +320,14 @@ public class MetricsLite2 implements Metrics {
             builder.append("Presently, none of them are allowed to send data.").append(System.lineSeparator());
         } else {
             builder.append("Presently, the following ").append(enabled.size()).append(" plugins are allowed to send data:").append(System.lineSeparator());
-            builder.append(enabled.toString()).append(System.lineSeparator());
+            builder.append(enabled).append(System.lineSeparator());
         }
         if (disabled.isEmpty()) {
             builder.append("None of them have data sending disabled.");
             builder.append(System.lineSeparator());
         } else {
             builder.append("Presently, the following ").append(disabled.size()).append(" plugins are not allowed to send data:").append(System.lineSeparator());
-            builder.append(disabled.toString()).append(System.lineSeparator());
+            builder.append(disabled).append(System.lineSeparator());
         }
         builder.append("To change the enabled/disabled state of any bStats use in a plugin, visit the Sponge config!");
         logger.info(builder.toString());
@@ -341,8 +340,7 @@ public class MetricsLite2 implements Metrics {
      */
     private JsonObject getServerData() {
         // Minecraft specific data
-        int playerAmount = Sponge.getServer().getOnlinePlayers().size();
-        playerAmount = playerAmount > 200 ? 200 : playerAmount;
+        int playerAmount = Math.min(Sponge.getServer().getOnlinePlayers().size(), 200);
         int onlineMode = Sponge.getServer().getOnlineMode() ? 1 : 0;
         String minecraftVersion = Sponge.getGame().getPlatform().getMinecraftVersion().getName();
         String spongeImplementation = Sponge.getPlatform().getContainer(Platform.Component.IMPLEMENTATION).getName();
@@ -482,17 +480,14 @@ public class MetricsLite2 implements Metrics {
      * Reads the first line of the file.
      *
      * @param file The file to read. Cannot be null.
-     * @return The first line of the file or <code>null</code> if the file does not exist or is empty.
+     * @return The first line of the file or {@code null} if the file does not exist or is empty.
      * @throws IOException If something did not work :(
      */
     private String readFile(File file) throws IOException {
         if (!file.exists()) {
             return null;
         }
-        try (
-                FileReader fileReader = new FileReader(file);
-                BufferedReader bufferedReader = new BufferedReader(fileReader);
-        ) {
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
             return bufferedReader.readLine();
         }
     }
@@ -507,7 +502,7 @@ public class MetricsLite2 implements Metrics {
     private static void sendData(Logger logger, JsonObject data) throws Exception {
         Validate.notNull(data, "Data cannot be null");
         if (logSentData) {
-            logger.info("Sending data to bStats: {}", data.toString());
+            logger.info("Sending data to bStats: {}", data);
         }
         HttpsURLConnection connection = (HttpsURLConnection) new URL(URL).openConnection();
 
@@ -525,22 +520,20 @@ public class MetricsLite2 implements Metrics {
 
         // Send data
         connection.setDoOutput(true);
-        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
-        outputStream.write(compressedData);
-        outputStream.flush();
-        outputStream.close();
-
-        InputStream inputStream = connection.getInputStream();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+            outputStream.write(compressedData);
+        }
 
         StringBuilder builder = new StringBuilder();
-        String line;
-        while ((line = bufferedReader.readLine()) != null) {
-            builder.append(line);
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                builder.append(line);
+            }
         }
-        bufferedReader.close();
+
         if (logResponseStatusText) {
-            logger.info("Sent data to bStats and received response: {}", builder.toString());
+            logger.info("Sent data to bStats and received response: {}", builder);
         }
     }
 
@@ -556,9 +549,9 @@ public class MetricsLite2 implements Metrics {
             return null;
         }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
-        gzip.write(str.getBytes(StandardCharsets.UTF_8));
-        gzip.close();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+            gzip.write(str.getBytes(StandardCharsets.UTF_8));
+        }
         return outputStream.toByteArray();
     }
 

--- a/bstats-sponge/src/main/java/org/bstats/sponge/Metrics.java
+++ b/bstats-sponge/src/main/java/org/bstats/sponge/Metrics.java
@@ -5,7 +5,7 @@ import org.spongepowered.api.plugin.PluginContainer;
 
 import java.util.List;
 
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings("unused")
 public interface Metrics {
     /**
      * Cancels this instance's scheduled data sending.

--- a/bstats-sponge/src/main/java/org/bstats/sponge/Metrics2.java
+++ b/bstats-sponge/src/main/java/org/bstats/sponge/Metrics2.java
@@ -237,11 +237,10 @@ public class Metrics2 implements Metrics {
 
         String pluginName = plugin.getName();
         String pluginVersion = plugin.getVersion().orElse("unknown");
-        int revision = getRevision();
 
         data.addProperty("pluginName", pluginName);
         data.addProperty("pluginVersion", pluginVersion);
-        data.addProperty("metricsRevision", revision);
+        data.addProperty("metricsRevision", B_STATS_CLASS_REVISION);
 
         JsonArray customCharts = new JsonArray();
         for (CustomChart customChart : charts) {
@@ -260,9 +259,9 @@ public class Metrics2 implements Metrics {
     private void startSubmitting() {
         // bStats 1 cleanup. Runs once.
         try {
-            Path configPath = configDir.resolve("bStats");
-            configPath.toFile().mkdirs();
-            String className = readFile(new File(configPath.toFile(), "temp.txt"));
+            File configPath = configDir.resolve("bStats").toFile();
+            configPath.mkdirs();
+            String className = readFile(new File(configPath, "temp.txt"));
             if (className != null) {
                 try {
                     // Let's check if a class with the given name exists.
@@ -344,14 +343,14 @@ public class Metrics2 implements Metrics {
             builder.append("Presently, none of them are allowed to send data.").append(System.lineSeparator());
         } else {
             builder.append("Presently, the following ").append(enabled.size()).append(" plugins are allowed to send data:").append(System.lineSeparator());
-            builder.append(enabled.toString()).append(System.lineSeparator());
+            builder.append(enabled).append(System.lineSeparator());
         }
         if (disabled.isEmpty()) {
             builder.append("None of them have data sending disabled.");
             builder.append(System.lineSeparator());
         } else {
             builder.append("Presently, the following ").append(disabled.size()).append(" plugins are not allowed to send data:").append(System.lineSeparator());
-            builder.append(disabled.toString()).append(System.lineSeparator());
+            builder.append(disabled).append(System.lineSeparator());
         }
         builder.append("To change the enabled/disabled state of any bStats use in a plugin, visit the Sponge config!");
         logger.info(builder.toString());
@@ -364,8 +363,7 @@ public class Metrics2 implements Metrics {
      */
     private JsonObject getServerData() {
         // Minecraft specific data
-        int playerAmount = Sponge.getServer().getOnlinePlayers().size();
-        playerAmount = playerAmount > 200 ? 200 : playerAmount;
+        int playerAmount = Math.min(Sponge.getServer().getOnlinePlayers().size(), 200);
         int onlineMode = Sponge.getServer().getOnlineMode() ? 1 : 0;
         String minecraftVersion = Sponge.getGame().getPlatform().getMinecraftVersion().getName();
         String spongeImplementation = Sponge.getPlatform().getContainer(Platform.Component.IMPLEMENTATION).getName();
@@ -439,9 +437,9 @@ public class Metrics2 implements Metrics {
      * @throws IOException If something did not work :(
      */
     private void loadConfig() throws IOException {
-        Path configPath = configDir.resolve("bStats");
-        configPath.toFile().mkdirs();
-        File configFile = new File(configPath.toFile(), "config.conf");
+        File configPath = configDir.resolve("bStats").toFile();
+        configPath.mkdirs();
+        File configFile = new File(configPath, "config.conf");
         HoconConfigurationLoader configurationLoader = HoconConfigurationLoader.builder().setFile(configFile).build();
         CommentedConfigurationNode node;
         if (!configFile.exists()) {
@@ -505,17 +503,14 @@ public class Metrics2 implements Metrics {
      * Reads the first line of the file.
      *
      * @param file The file to read. Cannot be null.
-     * @return The first line of the file or <code>null</code> if the file does not exist or is empty.
+     * @return The first line of the file or {@code null} if the file does not exist or is empty.
      * @throws IOException If something did not work :(
      */
     private String readFile(File file) throws IOException {
         if (!file.exists()) {
             return null;
         }
-        try (
-                FileReader fileReader = new FileReader(file);
-                BufferedReader bufferedReader = new BufferedReader(fileReader);
-        ) {
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
             return bufferedReader.readLine();
         }
     }
@@ -530,7 +525,7 @@ public class Metrics2 implements Metrics {
     private static void sendData(Logger logger, JsonObject data) throws Exception {
         Validate.notNull(data, "Data cannot be null");
         if (logSentData) {
-            logger.info("Sending data to bStats: {}", data.toString());
+            logger.info("Sending data to bStats: {}", data);
         }
         HttpsURLConnection connection = (HttpsURLConnection) new URL(URL).openConnection();
 
@@ -548,22 +543,19 @@ public class Metrics2 implements Metrics {
 
         // Send data
         connection.setDoOutput(true);
-        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
-        outputStream.write(compressedData);
-        outputStream.flush();
-        outputStream.close();
-
-        InputStream inputStream = connection.getInputStream();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+            outputStream.write(compressedData);
+        }
 
         StringBuilder builder = new StringBuilder();
-        String line;
-        while ((line = bufferedReader.readLine()) != null) {
-            builder.append(line);
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                builder.append(line);
+            }
         }
-        bufferedReader.close();
         if (logResponseStatusText) {
-            logger.info("Sent data to bStats and received response: {}", builder.toString());
+            logger.info("Sent data to bStats and received response: {}", builder);
         }
     }
 
@@ -579,9 +571,9 @@ public class Metrics2 implements Metrics {
             return null;
         }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
-        gzip.write(str.getBytes(StandardCharsets.UTF_8));
-        gzip.close();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+            gzip.write(str.getBytes(StandardCharsets.UTF_8));
+        }
         return outputStream.toByteArray();
     }
 


### PR DESCRIPTION
This fix compatiblity with bar charts on Bukkit versions before 1.12, because theses versions use Gson 2.2.4 wich don't have the method `JsonArray#add(Number)` (added in Gson 2.4) but only `JsonArray#add(JsonElement)`.
This should fix #54.

I have also cleanup some code:
* Use lambda and try-with-resource when possible
* Replace code with `File -> Path -> File` conversions to only `File`
* Remove unescessary use of `#toString()`
