### PR TITLE
Change Bukkit dependency versions to 1.8.3

### DIFF
--- a/bstats-bukkit-lite/pom.xml
+++ b/bstats-bukkit-lite/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.8.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bstats-bukkit/pom.xml
+++ b/bstats-bukkit/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.8.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This just changes the Bukkit dependency version from 1.13.2 to 1.8.3 in the Bukkit pom.xml files. (1.8.3 is the oldest API that provides GSON)

No code changes are needed. This is mostly for assurance that plugins for Bukkit 1.8-1.12 won't accidentally lose bStats support in the future.