### PR TITLE
Implement ThreadFactory for ExecutorService to enforce a naming convention

### DIFF
--- a/bstats-bukkit-lite/src/main/java/org/bstats/bukkit/MetricsLite.java
+++ b/bstats-bukkit-lite/src/main/java/org/bstats/bukkit/MetricsLite.java
@@ -22,6 +22,7 @@ import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.zip.GZIPOutputStream;
@@ -48,9 +49,12 @@ public class MetricsLite {
         }
     }
 
+    // This ThreadFactory enforces the naming convention for our Threads
+    private final ThreadFactory threadFactory = task -> new Thread(task, "bStats-Metrics");
+
     // Executor service for requests
     // We use an executor service because the Bukkit scheduler is affected by server lags
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, threadFactory);
 
     // The version of this bStats class
     public static final int B_STATS_VERSION = 1;

--- a/bstats-bukkit/src/main/java/org/bstats/bukkit/Metrics.java
+++ b/bstats-bukkit/src/main/java/org/bstats/bukkit/Metrics.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.zip.GZIPOutputStream;
@@ -47,9 +48,12 @@ public class Metrics {
         }
     }
 
+    // This ThreadFactory enforces the naming convention for our Threads
+    private final ThreadFactory threadFactory = task -> new Thread(task, "bStats-Metrics");
+
     // Executor service for requests
     // We use an executor service because the Bukkit scheduler is affected by server lags
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, threadFactory);
 
     // The version of this bStats class
     public static final int B_STATS_VERSION = 1;

--- a/bstats-sponge-lite/src/main/java/org/bstats/sponge/MetricsLite2.java
+++ b/bstats-sponge-lite/src/main/java/org/bstats/sponge/MetricsLite2.java
@@ -28,6 +28,7 @@ import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 
@@ -131,9 +132,12 @@ public class MetricsLite2 implements Metrics {
         }
     }
 
+    // This ThreadFactory enforces the naming convention for our Threads
+    private final ThreadFactory threadFactory = task -> new Thread(task, "bStats-Metrics");
+
     // Executor service for requests
     // We use an executor service to be independent of server TPS
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, threadFactory);
 
     // The version of bStats info being sent
     public static final int B_STATS_VERSION = 1;

--- a/bstats-sponge/src/main/java/org/bstats/sponge/Metrics2.java
+++ b/bstats-sponge/src/main/java/org/bstats/sponge/Metrics2.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 
@@ -133,9 +134,12 @@ public class Metrics2 implements Metrics {
         }
     }
 
+    // This ThreadFactory enforces the naming convention for our Threads
+    private final ThreadFactory threadFactory = task -> new Thread(task, "bStats-Metrics");
+
     // Executor service for requests
     // We use an executor service to be independent of server TPS
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, threadFactory);
 
     // The version of bStats info being sent
     public static final int B_STATS_VERSION = 1;


### PR DESCRIPTION
This Pull Request adds a very basic change to the `ExecutorService` which bStats runs on.
I added a `ThreadFactory` argument to the constructor which forces the Thread name "bStats-Metrics" (feel free to suggest an alternate naming scheme) onto any Threads created by the  `ExecutorService`. This makes it easier to distinguish the Thread from others and gives clear identification for the Thread's purpose.
Also, `ThreadFactory` exists since Java 1.5, so no worries in regards to compatibility issues, it's just a small QoL improvement.

Based on commit https://github.com/Bastian/bStats-Metrics/commit/d0f745b88b5e974f9aad5944fb96f69deb6b4658 I found that only the Bukkit and Sponge implementations use an `ExecutorService`, so I let the bungee implementation remain untouched.
I also didn't bump the version for it since I wanted to leave this up to you, it is a small change so it might as well be procrastinated till the next build.

The reason I found this was that I regularly use [Spark](https://github.com/lucko/spark) to run timings profiles and noticed a lot of unnamed Threads (`pool-4-thread` in this instance) showing up in pools like these. Upon further inspection I noticed all of them eventually lead to a `Metrics.java` implementation.
This change of thread names is nothing significant but a worthy QoL improvement for people with OCD and a habit of profiling things XD

![89c19bdf534ff967c941c4af2d6b6916](https://user-images.githubusercontent.com/3967898/104634200-9cc75f80-56a0-11eb-8f74-d77b6d9b8e49.png)
