### PR TITLE
Add overload for SimplePie to accept pritimive boolean-typed callables

### DIFF
--- a/base/src/main/java/org/bstats/charts/SimplePie.java
+++ b/base/src/main/java/org/bstats/charts/SimplePie.java
@@ -1,5 +1,6 @@
 package org.bstats.charts;
 
+import org.bstats.function.BooleanCallable;
 import org.bstats.json.JsonObjectBuilder;
 
 import java.util.concurrent.Callable;
@@ -17,6 +18,16 @@ public class SimplePie extends CustomChart {
     public SimplePie(String chartId, Callable<String> callable) {
         super(chartId);
         this.callable = callable;
+    }
+
+    /**
+     * Class constructor.
+     *
+     * @param chartId The id of the chart.
+     * @param callable The callable which is used to request the chart data
+     */
+    public SimplePie(String chartId, BooleanCallable callable) {
+        this(chartId, (Callable<String>) callable);
     }
 
     @Override

--- a/base/src/main/java/org/bstats/function/BooleanCallable.java
+++ b/base/src/main/java/org/bstats/function/BooleanCallable.java
@@ -1,0 +1,31 @@
+package org.bstats.function;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A task that returns a result and may throw an exception.
+ * Implementors define a single method with no arguments called
+ * {@code call}.
+ *
+ * <p>The {@code BooleanCallable} interface is a String-typed
+ * {@link Callable} interface with an additional method,
+ * {@link #callPrimitive()}, to call upon primitive boolean
+ * types and return their results as Strings.
+ */
+@FunctionalInterface
+public interface BooleanCallable extends Callable<String> {
+
+    @Override
+    default String call() throws Exception {
+        return callPrimitive() ? "true" : "false";
+    }
+
+    /**
+     * Computes a result, or throws an exception if unable to do so.
+     *
+     * @return computed result
+     * @throws Exception if unable to compute a result
+     */
+    boolean callPrimitive() throws Exception;
+
+}


### PR DESCRIPTION
A common use for simple pie charts are just true/false pie slices and that can be quite awkward to define currently. This change adds a new FunctionalInterface which allows callers to return a primitive-typed boolean to more conveniently define true/false pie charts without having to use either a ternary or a call to toString().

```java
metrics.addCustomChart(new SimplePie("alchema_integration", () -> String.valueOf(alchemaInstalled))); // Old
```
```java
metrics.addCustomChart(new SimplePie("alchema_integration", () -> alchemaInstalled)); // New
```