### PR TITLE
Added Krypton support

### DIFF
--- a/krypton/build.gradle.kts
+++ b/krypton/build.gradle.kts
@@ -1,0 +1,27 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm") version "1.4.32"
+}
+
+repositories {
+    mavenCentral()
+    maven("https://repo.bristermitten.me/repository/maven-public/")
+}
+
+dependencies {
+    api(project(":base")) {
+        isTransitive = true
+    }
+    compileOnly(kotlin("stdlib"))
+    compileOnly("org.kryptonmc:krypton-api:0.18.3")
+}
+
+tasks {
+    withType<KotlinCompile> {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+    withType<Test> {
+        useJUnitPlatform()
+    }
+}

--- a/krypton/src/main/kotlin/org/bstats/krypton/Metrics.kt
+++ b/krypton/src/main/kotlin/org/bstats/krypton/Metrics.kt
@@ -1,0 +1,58 @@
+package org.bstats.krypton
+
+import org.bstats.MetricsBase
+import org.bstats.charts.CustomChart
+import org.bstats.config.MetricsConfig
+import org.bstats.json.JsonObjectBuilder
+import org.kryptonmc.krypton.api.plugin.Plugin
+import org.kryptonmc.krypton.api.plugin.PluginLoadState
+import java.nio.file.Path
+
+class Metrics(private val plugin: Plugin, serviceId: Int) {
+
+    private val server = plugin.context.server
+    private val base: MetricsBase
+
+    init {
+        val configFile = Path.of("").resolve("plugins").resolve("bStats").resolve("config.txt").toFile()
+        val config = MetricsConfig(configFile, true)
+
+        base = MetricsBase(
+            "krypton",
+            config.serverUUID,
+            serviceId,
+            config.isEnabled,
+            ::appendPlatformData,
+            ::appendServiceData,
+            { server.scheduler.run(plugin) { it.run() } },
+            { plugin.loadState == PluginLoadState.INITIALIZED },
+            plugin.context.logger::error,
+            plugin.context.logger::info,
+            config.isLogErrorsEnabled,
+            config.isLogSentDataEnabled,
+            config.isLogResponseStatusTextEnabled
+        )
+    }
+
+    @JvmName("addCustomChart")
+    operator fun plusAssign(chart: CustomChart) {
+        base.addCustomChart(chart)
+    }
+
+    private fun appendPlatformData(builder: JsonObjectBuilder) {
+        builder.appendField("playerAmount", server.players.size)
+        builder.appendField("onlineMode", if (server.isOnline) 1 else 0)
+        builder.appendField("kryptonVersion", server.info.version)
+        builder.appendField("kryptonName", server.info.name)
+
+        builder.appendField("javaVersion", System.getProperty("java.version"))
+        builder.appendField("osName", System.getProperty("os.name"))
+        builder.appendField("osArch", System.getProperty("os.arch"))
+        builder.appendField("osVersion", System.getProperty("os.version"))
+        builder.appendField("coreCount", Runtime.getRuntime().availableProcessors())
+    }
+
+    private fun appendServiceData(builder: JsonObjectBuilder) {
+        builder.appendField("pluginVersion", plugin.context.description.version)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
 rootProject.name = "bstats-metrics"
-include("base", "bukkit", "bungeecord", "sponge", "velocity")
+include("base", "bukkit", "bungeecord", "krypton", "sponge", "velocity")


### PR DESCRIPTION
Not sure if this one will get merged, as no other project has accepted an implementation for this platform for their software before, but I guess it's worth a go anyway.

This PR adds support for my new Minecraft server project, [Krypton](https://github.com/KryptonMC/Krypton). Specifically, this is for use in plugins (I know there needs to be changes to the backend before this works, but I thought that giving plugins this option in the first place may encourage plugins to make use of it).

Feel free to flame me for anything you're not happy with. Oh, and also, I'm perfectly happy to maintain this myself, I don't think it's fair to put this sort of burden on other developers when I'm the one who wants this.