### PR TITLE
Submit data asynchronously on bukkit/spigot rather than on server thread

### DIFF
--- a/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
+++ b/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
@@ -70,7 +70,7 @@ public class Metrics {
                 enabled,
                 this::appendPlatformData,
                 this::appendServiceData,
-                submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+                submitDataTask -> Bukkit.getScheduler().runTaskAsynchronously(plugin, submitDataTask),
                 plugin::isEnabled,
                 (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
                 (message) -> this.plugin.getLogger().log(Level.INFO, message),


### PR DESCRIPTION
Don't submit data on server thread, can create lag spikes.

Not sure if it is necessary to run on server thread for spigot servers, so not sure what the side effects are.