### PR TITLE
Change how scheduler is shutdown

### DIFF
--- a/base/src/main/java/org/bstats/MetricsBase.java
+++ b/base/src/main/java/org/bstats/MetricsBase.java
@@ -113,7 +113,7 @@ public class MetricsBase {
     }
 
     public void shutdown() {
-        scheduler.shutdown();
+        scheduler.shutdownNow();
     }
 
     private void startSubmitting() {


### PR DESCRIPTION
`shutdown()` doesn't seem to suffice - the server still hangs for some unknown amount of time at shutdown, on Fabric. I suspect this is because `shutdown()` only stops the scheduler from accepting *new* tasks.