### PR TITLE
Send BungeeCord fork name

### DIFF
--- a/bungeecord/src/main/java/org/bstats/bungeecord/Metrics.java
+++ b/bungeecord/src/main/java/org/bstats/bungeecord/Metrics.java
@@ -123,6 +123,7 @@ public class Metrics {
         builder.appendField("managedServers", plugin.getProxy().getServers().size());
         builder.appendField("onlineMode", plugin.getProxy().getConfig().isOnlineMode() ? 1 : 0);
         builder.appendField("bungeecordVersion", plugin.getProxy().getVersion());
+        builder.appendField("bungeecordName", plugin.getProxy().getName());
 
         builder.appendField("javaVersion", System.getProperty("java.version"));
         builder.appendField("osName", System.getProperty("os.name"));


### PR DESCRIPTION
Due to the version part showing custom versioning like FlameCord's, add support to fork name counting.