### PR TITLE
Use Plugin instead of JavaPlugin in Bukkit Metrics constructor

### DIFF
--- a/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
+++ b/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
@@ -7,7 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +27,7 @@ public class Metrics {
      * @param serviceId The id of the service.
      *                  It can be found at <a href="https://bstats.org/what-is-my-plugin-id">What is my plugin id?</a>
      */
-    public Metrics(JavaPlugin plugin, int serviceId) {
+    public Metrics(Plugin plugin, int serviceId) {
         this.plugin = plugin;
 
         // Get the config file


### PR DESCRIPTION
`Plugin` is an abstract base type for all plugin types supported by the Bukkit plugin loading API. Specifically requiring `JavaPlugin` [forces 3rd party plugin loaders such as PyPlugins to use older versions of bStats](https://github.com/pyplugins/pyplugins#development) because they cannot pass instances of `PythonPlugin`. `JavaPlugin` isn't strictly required for the `Metrics` class and even has a `Plugin` field so this change is rather harmless but allows plugin loaders to still use bStats.