### PR TITLE
support for folia

### DIFF
--- a/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
+++ b/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
@@ -62,14 +62,10 @@ public class Metrics {
         boolean logSentData = config.getBoolean("logSentData", false);
         boolean logResponseStatusText = config.getBoolean("logResponseStatusText", false);
 
-        Class clazz = null;
-
+        boolean isFolia = false;
         try {
-            clazz = Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
-        } catch (Exception e) {
-        }
-
-        boolean folia = (clazz != null);
+            isFolia = Class.forName("io.papermc.paper.threadedregions.RegionizedServer") != null;
+        } catch (Exception e) {}
 
         metricsBase = new MetricsBase(
                 "bukkit",
@@ -78,7 +74,8 @@ public class Metrics {
                 enabled,
                 this::appendPlatformData,
                 this::appendServiceData,
-                folia ? null : submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+                // See https://github.com/Bastian/bstats-metrics/pull/126
+                isFolia ? null : submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
                 plugin::isEnabled,
                 (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
                 (message) -> this.plugin.getLogger().log(Level.INFO, message),

--- a/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
+++ b/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
@@ -62,8 +62,14 @@ public class Metrics {
         boolean logSentData = config.getBoolean("logSentData", false);
         boolean logResponseStatusText = config.getBoolean("logResponseStatusText", false);
 
-        String minecraftVersion2 = Bukkit.getServer().getName();
-        boolean folia = (minecraftVersion2.toUpperCase().contains("FOLIA"));
+        Class clazz = null;
+
+        try {
+            clazz = Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+        } catch (Exception e) {
+        }
+
+        boolean folia = (clazz != null);
 
         metricsBase = new MetricsBase(
                 "bukkit",

--- a/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
+++ b/bukkit/src/main/java/org/bstats/bukkit/Metrics.java
@@ -23,7 +23,7 @@ public class Metrics {
     /**
      * Creates a new Metrics instance.
      *
-     * @param plugin Your plugin instance.
+     * @param plugin    Your plugin instance.
      * @param serviceId The id of the service.
      *                  It can be found at <a href="https://bstats.org/what-is-my-plugin-id">What is my plugin id?</a>
      */
@@ -62,6 +62,9 @@ public class Metrics {
         boolean logSentData = config.getBoolean("logSentData", false);
         boolean logResponseStatusText = config.getBoolean("logResponseStatusText", false);
 
+        String minecraftVersion2 = Bukkit.getServer().getName();
+        boolean folia = (minecraftVersion2.toUpperCase().contains("FOLIA"));
+
         metricsBase = new MetricsBase(
                 "bukkit",
                 serverUUID,
@@ -69,7 +72,7 @@ public class Metrics {
                 enabled,
                 this::appendPlatformData,
                 this::appendServiceData,
-                submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+                folia ? null : submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
                 plugin::isEnabled,
                 (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
                 (message) -> this.plugin.getLogger().log(Level.INFO, message),
@@ -78,6 +81,7 @@ public class Metrics {
                 logResponseStatusText,
                 false
         );
+
     }
 
     /**


### PR DESCRIPTION
SubmitTaskConsumer seems to halt processing on the scheduler with Folia and since the scheduler itself is usable in schedule and scheduleAtFixedRate methods, so on folia version it is passed a null  in order to force call this.submitData().

Tested with auto-generated Metrics class for bukkit with the changes presented here with bstats https://bstats.org/plugin/bukkit/CoolGateway/23166

Regards