### PR TITLE
Sponge: set `enabled` to false by default, do not use comment as `serverUuid` value

### DIFF
--- a/sponge/src/main/java/org/bstats/sponge/Metrics.java
+++ b/sponge/src/main/java/org/bstats/sponge/Metrics.java
@@ -139,6 +139,7 @@ public class Metrics {
             configFile.createNewFile();
             node = configurationLoader.load();
 
+            node.node("enabled").set(false);
             node.node("serverUuid").set(UUID.randomUUID().toString());
             node.node("logFailedRequests").set(false);
             node.node("logSentData").set(false);


### PR DESCRIPTION
I'm not familiar with Sponge so I'm not sure if the `enabled` parameter should be there (I would assume it should based on the comment below) or if the `serverUuid` value is even used in the first place, but using `org.bstats:bstats-sponge:3.1.0` causes the configuration file to look like this on a brand new SpongeVanilla server (using build `1.21.7-16.0.0-RC2265`):
```conf
# bStats (https://bStats.org) collects some basic information for plugin authors, like how
# many people use their plugin and their total player count. It's recommended to keep bStats
# enabled, but if you're not comfortable with this, you can disable data collection in the
# Sponge configuration file. There is no performance penalty associated with having metrics
# enabled, and data sent to bStats is fully anonymous.
serverUuid="bStats (https://bStats.org) collects some basic information for plugin authors, like how\nmany people use their plugin and their total player count. It's recommended to keep bStats\nenabled, but if you're not comfortable with this, you can disable data collection in the\nSponge configuration file. There is no performance penalty associated with having metrics\nenabled, and data sent to bStats is fully anonymous."
logFailedRequests=true
logSentData=true
logResponseStatusText=true
configVersion=2
# Enabling bStats in this file is deprecated. At least one of your plugins now uses the
# Sponge config to control bStats. Leave this value as you want it to be for outdated plugins,
# but look there for further control
enabled=null
```

This PR changes `enabled` to be `false` by default instead of `null` and assigns a proper UUID to `serverUuid`
