### PR TITLE
Add NeoForge metrics support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /*/build/
 /build/
 .idea
+.agent-review/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository contains the code for all Java-based Metrics classes.
 
+## Modules
+
+The NeoForge module is configured to publish as `org.bstats:bstats-neoforge`.
+NeoForge mods can depend on that artifact when using Gradle or Maven-based
+dependency management.
+
 ## Code Generation
 
 The recommended way to include the Metrics classes is to use a build management tool like Gradle or Maven and
@@ -12,6 +18,10 @@ release and pushed to the `single-file` branch. This file can simply be copy-and
 
 To generate a Metrics class locally, you can run the `gradlew generateMetrics` command.
 It will write the generated files into the `<platform>/build/generated/` directory.
+
+For local or private NeoForge runtime validation, use the
+[`NeoForge Runtime Smoke Test Plan`](docs/neoforge-runtime-smoke-test.md). Do
+not point smoke-test telemetry at upstream `https://bStats.org`.
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository contains the code for all Java-based Metrics classes.
 
 The NeoForge module is configured to publish as `org.bstats:bstats-neoforge`.
 NeoForge mods can depend on that artifact when using Gradle or Maven-based
-dependency management.
+dependency management, then shade and relocate it into the consuming mod's
+package.
 
 ## Code Generation
 

--- a/docs/neoforge-runtime-smoke-test.md
+++ b/docs/neoforge-runtime-smoke-test.md
@@ -22,8 +22,10 @@ upstream bStats ingestion.
   The committed default template is `https://bStats.org/api/v2/data/%s`, which resolves to
   `/api/v2/data/neoforge`. If the disposable copy is patched to a private template such as
   `/submitData/%s`, configure the receiver for the resulting `/submitData/neoforge` path.
-- JDK for generation: `C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot`
-- JDK for NeoForge compile/runtime work: `C:\Program Files\Eclipse Adoptium\jdk-25.0.3.9-hotspot`
+- JDK for generation: JDK 17
+- JDK for NeoForge compile/runtime work: JDK 25
+
+Use local installation paths for those JDK versions when setting `JAVA_HOME`.
 
 ## Safety Rules
 
@@ -41,10 +43,10 @@ upstream bStats ingestion.
 From the active source worktree, generate and compile the NeoForge metrics artifact:
 
 ```powershell
-$env:JAVA_HOME = 'C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot'
+$env:JAVA_HOME = '<path-to-jdk17>'
 .\gradlew.bat generateMetrics
 
-$env:JAVA_HOME = 'C:\Program Files\Eclipse Adoptium\jdk-25.0.3.9-hotspot'
+$env:JAVA_HOME = '<path-to-jdk25>'
 .\gradlew.bat :neoforge:compileJava
 ```
 

--- a/docs/neoforge-runtime-smoke-test.md
+++ b/docs/neoforge-runtime-smoke-test.md
@@ -1,0 +1,172 @@
+# NeoForge Runtime Smoke Test Plan
+
+This plan is for local or private validation of the NeoForge metrics class before release. It must
+not deploy, publish, release, or send smoke-test telemetry to upstream `https://bStats.org`.
+
+## Scope
+
+Validate that a disposable NeoForge test mod can initialize the generated bStats Metrics class,
+create the local bStats config, capture server lifecycle data, and submit one metrics payload to a
+local or private receiver.
+
+This plan does not verify Maven Central publishing, GitHub releases, production dashboards, or
+upstream bStats ingestion.
+
+## Inputs
+
+- Source module: `neoforge/src/main/java/org/bstats/neoforge/Metrics.java`
+- Generated single-file output: `neoforge/build/generated/Metrics.java`
+- Gradle generation task: `generateMetrics`
+- NeoForge compile check: `:neoforge:compileJava`
+- Local/private receiver: an operator-controlled endpoint that accepts the NeoForge platform path.
+  The committed default template is `https://bStats.org/api/v2/data/%s`, which resolves to
+  `/api/v2/data/neoforge`. If the disposable copy is patched to a private template such as
+  `/submitData/%s`, configure the receiver for the resulting `/submitData/neoforge` path.
+- JDK for generation: `C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot`
+- JDK for NeoForge compile/runtime work: `C:\Program Files\Eclipse Adoptium\jdk-25.0.3.9-hotspot`
+
+## Safety Rules
+
+- Use a disposable NeoForge test mod or disposable runtime copy only.
+- Do not modify committed bStats source to point at a private endpoint.
+- Do not point any smoke-test payload at upstream `https://bStats.org`.
+- Patch only the copied generated `Metrics.java` used by the disposable test mod.
+- Change the copied generated package away from `org.bstats.neoforge`; the generated relocation guard
+  intentionally rejects bStats-owned packages at runtime.
+- Confirm the private receiver is reachable before enabling metrics in the test runtime.
+- Keep `config/bStats/config.txt` under the disposable runtime directory, not a shared server.
+
+## Preparation
+
+From the active source worktree, generate and compile the NeoForge metrics artifact:
+
+```powershell
+$env:JAVA_HOME = 'C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot'
+.\gradlew.bat generateMetrics
+
+$env:JAVA_HOME = 'C:\Program Files\Eclipse Adoptium\jdk-25.0.3.9-hotspot'
+.\gradlew.bat :neoforge:compileJava
+```
+
+Copy `neoforge/build/generated/Metrics.java` into a disposable NeoForge test mod. In that copy only:
+
+- Change the package to the test mod's package, for example `dev.example.smoke.bstats`.
+- Replace the generated bStats report URL with the private receiver URL pattern, keeping the `%s`
+  platform placeholder so NeoForge resolves to the NeoForge path.
+- If the private receiver is HTTP-only, patch the disposable copy's connection type from
+  `HttpsURLConnection` to `HttpURLConnection`; do not make that transport change in committed
+  bStats source.
+- Ensure the private receiver decompresses gzip-encoded request bodies before logging or inspecting
+  payload JSON. A receiver that only logs raw bytes can prove a POST arrived, but cannot prove the
+  submitted JSON body.
+- Instantiate the class from server-side mod initialization with the disposable test mod id and a
+  dummy service id such as `99999`. Do not use a real production bStats service id in the
+  disposable smoke test.
+
+The private receiver must be able to log enough request data to prove a POST reached the NeoForge
+metrics path. If the receiver only supports another platform path, add a local-only NeoForge handler
+before running the smoke test.
+
+## Pre-Runtime Readiness Checklist
+
+Complete this checklist before starting any disposable NeoForge server. These steps prepare local or
+private inputs only; they do not require a server run, deployment, publication, or upstream bStats
+traffic.
+
+- Confirm the private receiver target is local or private and is not `https://bStats.org`.
+- Confirm the receiver accepts `POST` requests for the exact NeoForge path produced by the
+  disposable URL pattern, for example `/submitData/neoforge`.
+- Confirm the receiver decompresses gzip request bodies before logging payload JSON.
+- Confirm the disposable test mod package name is not `org.bstats.neoforge`.
+- Confirm the disposable generated copy keeps the platform placeholder in the report URL pattern,
+  for example `http://private-receiver:18080/submitData/%s`.
+- If using an HTTP-only receiver, confirm only the disposable generated copy changes
+  `HttpsURLConnection` to `HttpURLConnection`.
+- Confirm the disposable test mod uses a dummy service id, such as `99999`.
+- Confirm the disposable runtime directory is isolated and has no shared
+  `config/bStats/config.txt` from another server.
+- Confirm `generateMetrics` passed with JDK 17 and produced
+  `neoforge/build/generated/Metrics.java`.
+- Confirm `:neoforge:compileJava` passed with JDK 25.
+
+Do not proceed to runtime testing when any readiness item is missing. Fix the disposable test mod or
+private receiver first, then rerun the readiness checklist.
+
+## Runtime Steps
+
+1. Start the private receiver and verify its health endpoint or equivalent local readiness check.
+2. Start the disposable NeoForge server with the disposable test mod installed.
+3. Verify the server log reports the NeoForge mod initialized and no bStats relocation error occurred.
+4. Verify `config/bStats/config.txt` was created under the disposable runtime directory.
+5. Keep `enabled=true` only while the private receiver endpoint is active and confirmed local/private.
+6. Wait for the first metrics submission window, or use the smallest safe disposable runtime setup
+   that reaches the scheduler path without changing committed bStats code.
+7. Stop the server cleanly and confirm the bStats shutdown path does not log a warning.
+
+## Evidence To Capture
+
+- The generated source exists at `neoforge/build/generated/Metrics.java` after `generateMetrics`.
+- `:neoforge:compileJava` passes with JDK 25.
+- The disposable server log shows NeoForge server startup completed.
+- The disposable server log shows no bStats relocation error, config creation failure, or lifecycle
+  listener failure.
+- The disposable runtime contains `config/bStats/config.txt` with `enabled=true` during the test.
+- The private receiver log shows one POST to the NeoForge metrics path with a non-empty JSON body.
+  Spot-check at least the `platform` and `service.id` fields to confirm the payload shape matches
+  the disposable NeoForge test.
+- The private receiver log shows the response status returned for the POST.
+- The disposable server stops without bStats shutdown warnings.
+
+## Still Unverified Until Runtime Approval
+
+- Actual payload shape from a live NeoForge server.
+- Whether the private receiver accepts the NeoForge path, HTTPS or disposable HTTP transport, and
+  compressed request body used by the generated metrics class.
+- Whether server lifecycle event registration captures player count and online mode during a real
+  NeoForge run.
+- Whether a shaded or copied Metrics class in a downstream mod behaves correctly after relocation.
+
+## Evidence Template
+
+Copy this template into a local-only note for the approved runtime run. Do not commit private server
+names, payload bodies, UUIDs, or operator-specific paths unless they are intentionally scrubbed.
+
+```text
+NeoForge bStats Runtime Smoke Evidence
+
+Source worktree:
+Commit:
+Disposable test mod package:
+Disposable service id:
+Private receiver base URL: <scrub before committing>
+Resolved metrics path: <scrub before committing if it includes private host details>
+Disposable runtime directory: <scrub before committing>
+
+Pre-runtime checks:
+- JDK 17 generateMetrics:
+- Generated source exists:
+- JDK 25 :neoforge:compileJava:
+- Receiver health/readiness:
+- Receiver accepts NeoForge metrics path:
+- Receiver decompresses gzip body:
+- Disposable copy package changed away from org.bstats.neoforge:
+- Disposable copy report URL points only at local/private receiver:
+- Disposable copy transport patch, if any:
+
+Runtime evidence:
+- NeoForge server startup completed:
+- Disposable test mod initialized:
+- No bStats relocation error:
+- No config creation failure:
+- No lifecycle listener failure:
+- config/bStats/config.txt created under disposable runtime:
+- enabled=true only while private receiver was active:
+- Receiver POST path:
+- Receiver response status:
+- Payload platform field:
+- Payload service.id field:
+- Server stopped cleanly:
+- No bStats shutdown warning:
+
+Notes and follow-up:
+```

--- a/generate-metrics.gradle.kts
+++ b/generate-metrics.gradle.kts
@@ -20,6 +20,7 @@ tasks.register("generateMetrics") {
     doLast {
         generatePlatformMetricsClass("bukkit", false)
         generatePlatformMetricsClass("bungeecord", false)
+        generatePlatformMetricsClass("neoforge", true)
         generatePlatformMetricsClass("sponge", false)
         generatePlatformMetricsClass("velocity", true)
         generatePlatformMetricsClass("hytale", true)

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        name = "neoforge"
+        url = uri("https://maven.neoforged.net/releases/")
+    }
+    maven {
+        name = "mojang"
+        url = uri("https://libraries.minecraft.net/")
+    }
+}
+
+dependencies {
+    compileOnly("net.neoforged:neoforge:26.1.2.75")
+    compileOnly("net.neoforged.fancymodloader:loader:11.0.13")
+    api(project(":base"))
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
+    withJavadocJar()
+    withSourcesJar()
+}

--- a/neoforge/src/main/java/org/bstats/neoforge/Metrics.java
+++ b/neoforge/src/main/java/org/bstats/neoforge/Metrics.java
@@ -1,0 +1,209 @@
+package org.bstats.neoforge;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.fml.loading.FMLPaths;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import net.neoforged.neoforge.event.server.ServerStoppedEvent;
+import org.bstats.MetricsBase;
+import org.bstats.charts.CustomChart;
+import org.bstats.config.MetricsConfig;
+import org.bstats.json.JsonObjectBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * bStats Metrics for NeoForge server mods.
+ *
+ * <p>This class is intended to be created from server-side mod initialization. When it is loaded
+ * in a client environment, the constructor returns before creating the bStats config file, starting
+ * the scheduler, or preparing telemetry data.
+ *
+ * <p>The config file is stored in {@code config/bStats/config.txt} below NeoForge's config
+ * directory.
+ */
+public class Metrics {
+
+    private static final Logger LOGGER = Logger.getLogger("bStats");
+
+    private final String modId;
+
+    private final MetricsBase metricsBase;
+    private volatile Object minecraftServer;
+    private final AtomicBoolean listenerRegistered = new AtomicBoolean();
+
+    /**
+     * Creates a new Metrics class for a NeoForge server mod.
+     *
+     * <p>NeoForge server lifecycle events are used to capture the Minecraft server instance so
+     * this class can collect player count and online mode without pushing that work to mod
+     * authors.
+     *
+     * @param modId The NeoForge id of the mod.
+     * @param serviceId The id of the bStats service.
+     *                  It can be found at <a href="https://bstats.org/what-is-my-plugin-id">What is my plugin id?</a>
+     *                  <p>Not to be confused with the NeoForge mod id!
+     */
+    public Metrics(String modId, int serviceId) {
+        this.modId = Objects.requireNonNull(modId, "modId");
+
+        if (FMLEnvironment.getDist() != Dist.DEDICATED_SERVER) {
+            metricsBase = null;
+            return;
+        }
+
+        File configFile = FMLPaths.CONFIGDIR.get().resolve("bStats").resolve("config.txt").toFile();
+        MetricsConfig config;
+        try {
+            config = new MetricsConfig(configFile, true);
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to create bStats config", e);
+            metricsBase = null;
+            return;
+        }
+
+        metricsBase = new MetricsBase(
+                "neoforge",
+                config.getServerUUID(),
+                serviceId,
+                config.isEnabled(),
+                this::appendPlatformData,
+                this::appendServiceData,
+                null,
+                () -> true,
+                (message, error) -> LOGGER.log(Level.WARNING, message, error),
+                LOGGER::info,
+                config.isLogErrorsEnabled(),
+                config.isLogSentDataEnabled(),
+                config.isLogResponseStatusTextEnabled(),
+                false
+        );
+        NeoForge.EVENT_BUS.register(this);
+        listenerRegistered.set(true);
+
+        if (!config.didExistBefore()) {
+            // Send an info message when the bStats config file gets created for the first time
+            LOGGER.info("NeoForge and some of its mods collect metrics and send them to bStats (https://bStats.org).");
+            LOGGER.info("bStats collects some basic information for mod authors, like how many people use");
+            LOGGER.info("their mod and their total player count. It's recommended to keep bStats enabled, but");
+            LOGGER.info("if you're not comfortable with this, you can opt-out by editing the config.txt file in");
+            LOGGER.info("the '/config/bStats/' folder and setting enabled to false.");
+        }
+    }
+
+    /**
+     * Shuts down the underlying scheduler service.
+     */
+    public void shutdown() {
+        if (listenerRegistered.compareAndSet(true, false)) {
+            NeoForge.EVENT_BUS.unregister(this);
+        }
+        if (metricsBase != null) {
+            metricsBase.shutdown();
+        }
+    }
+
+    /**
+     * Adds a custom chart.
+     *
+     * @param chart The chart to add.
+     */
+    public void addCustomChart(CustomChart chart) {
+        if (metricsBase != null) {
+            metricsBase.addCustomChart(chart);
+        }
+    }
+
+    private void appendPlatformData(JsonObjectBuilder builder) {
+        builder.appendField("playerAmount", getPlayerAmount());
+        builder.appendField("onlineMode", isOnlineMode() ? 1 : 0);
+        builder.appendField("minecraftVersion", getModVersion("minecraft"));
+        builder.appendField("neoforgeVersion", getModVersion("neoforge"));
+
+        builder.appendField("javaVersion", System.getProperty("java.version"));
+        builder.appendField("osName", System.getProperty("os.name"));
+        builder.appendField("osArch", System.getProperty("os.arch"));
+        builder.appendField("osVersion", System.getProperty("os.version"));
+        builder.appendField("coreCount", Runtime.getRuntime().availableProcessors());
+    }
+
+    private void appendServiceData(JsonObjectBuilder builder) {
+        builder.appendField("pluginVersion", getModVersion(modId));
+    }
+
+    private String getModVersion(String id) {
+        Optional<? extends ModContainer> modContainer = ModList.get().getModContainerById(id);
+        if (!modContainer.isPresent()) {
+            return "unknown";
+        }
+        return modContainer.get().getModInfo().getVersion().toString();
+    }
+
+    /**
+     * Captures the active server once NeoForge finishes server startup.
+     *
+     * @param event The server started event.
+     */
+    @SubscribeEvent
+    public void onServerStarted(ServerStartedEvent event) {
+        minecraftServer = getServer(event);
+    }
+
+    /**
+     * Clears server state and shuts down bStats when NeoForge stops the server.
+     *
+     * @param event The server stopped event.
+     */
+    @SubscribeEvent
+    public void onServerStopped(ServerStoppedEvent event) {
+        minecraftServer = null;
+        shutdown();
+    }
+
+    private int getPlayerAmount() {
+        Object playerAmount = invokeMinecraftServerMethod("getPlayerCount");
+        if (playerAmount instanceof Number) {
+            return ((Number) playerAmount).intValue();
+        }
+        return 0;
+    }
+
+    private boolean isOnlineMode() {
+        Object onlineMode = invokeMinecraftServerMethod("usesAuthentication");
+        return onlineMode instanceof Boolean && (Boolean) onlineMode;
+    }
+
+    private Object getServer(Object event) {
+        return invokeNoArgs(event, "getServer");
+    }
+
+    private Object invokeMinecraftServerMethod(String methodName) {
+        Object server = minecraftServer;
+        if (server == null) {
+            return null;
+        }
+        return invokeNoArgs(server, methodName);
+    }
+
+    private Object invokeNoArgs(Object target, String methodName) {
+        try {
+            Method method = target.getClass().getMethod(methodName);
+            return method.invoke(target);
+        } catch (ReflectiveOperationException e) {
+            LOGGER.log(Level.FINE, "Failed to call " + methodName + " for bStats", e);
+            return null;
+        }
+    }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 rootProject.name = "bstats-metrics"
-include("base", "bukkit", "bungeecord", "sponge", "velocity", "hytale")
+include("base", "bukkit", "bungeecord", "neoforge", "sponge", "velocity", "hytale")
 
 nmcpSettings {
     centralPortal {


### PR DESCRIPTION
## Summary
Adds a NeoForge Metrics module, generated alongside the existing bStats metrics classes.

NeoForge is the current Forge-family mod loader. This module keeps the usual bStats config file behavior and submits raw server-side metrics data from NeoForge mods.

## Testing
- JDK 17: `./gradlew.bat generateMetrics`
- JDK 25: `./gradlew.bat :neoforge:compileJava`

Runtime smoke telemetry was not run in this branch; it should use a private/local receiver, not upstream bStats.